### PR TITLE
Refactor: Cambiar api vieja por la de Tracker.gg

### DIFF
--- a/.github/instructions/snyk_rules.instructions.md
+++ b/.github/instructions/snyk_rules.instructions.md
@@ -1,0 +1,14 @@
+---
+alwaysApply: true
+always_on: true
+trigger: always_on
+applyTo: "**"
+description: Snyk Security At Inception
+---
+
+# Project security best practices
+
+- Always run snyk_code_scan tool for new first party code that is generated in a Snyk-supported language.
+- If any security issues are found based on newly introduced or modified code or dependencies, attempt to fix the issues using the results context from Snyk.
+- Rescan the code after fixing the issues to ensure that the issues were fixed and that there are no newly introduced issues.
+- Repeat this process until no new issues are found.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "snyk.advanced.organization": "7bf69418-2b0f-4000-a0f6-97845664e1c0",
+    "snyk.advanced.autoSelectOrganization": true
+}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "start": "bun run build && bun --env-file=.env ./dist/index.ts",
     "prepare": "ts-patch install",
     "build": "bunx rimraf dist && typia generate --input src --output dist --project tsconfig.json",
-    "production": "bun run build && bun --env-file=.env ./dist/index.ts production"
+    "production": "bun run build && bun --env-file=.env ./dist/index.ts production",
+    "dev": "bun run build && bun --watch --env-file=.env ./dist/index.ts",
+    "debug": "bun run build && bun --inspect --watch --env-file=.env ./dist/index.ts"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,2653 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@napi-rs/canvas':
+        specifier: ^0.1.92
+        version: 0.1.93
+      '@prisma/client':
+        specifier: '6.19'
+        version: 6.19.2(prisma@6.19.2(typescript@5.9.3))(typescript@5.9.3)
+      '@redis/client':
+        specifier: ^5.11.0
+        version: 5.11.0
+      '@resvg/resvg-js':
+        specifier: ^2.6.2
+        version: 2.6.2
+      '@top-gg/sdk':
+        specifier: ^3.1.6
+        version: 3.1.6
+      cheerio:
+        specifier: ^1.2.0
+        version: 1.2.0
+      didyoumean2:
+        specifier: ^7.0.4
+        version: 7.0.4
+      domhandler:
+        specifier: ^5.0.3
+        version: 5.0.3
+      prisma:
+        specifier: '6.19'
+        version: 6.19.2(typescript@5.9.3)
+      satori:
+        specifier: ^0.19.2
+        version: 0.19.2
+      satori-html:
+        specifier: ^0.3.2
+        version: 0.3.2
+      seyfert:
+        specifier: ^4.2.2-dev-22071590650.0
+        version: 4.2.2-dev-22071590650.0
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+    devDependencies:
+      '@marcrock22/eslint':
+        specifier: github:marcrock22/eslintcf
+        version: https://codeload.github.com/marcrock22/eslintcf/tar.gz/df5c32a96ebd80f273b64398552548c5fef4dede(@eslint/js@9.39.2)(@stylistic/eslint-plugin@2.13.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(@typescript-eslint/utils@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-perfectionist@4.15.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript-eslint@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))
+      '@types/bun':
+        specifier: ^1.3.9
+        version: 1.3.9
+      eslint:
+        specifier: ^9.39.2
+        version: 9.39.2(jiti@2.6.1)
+      rimraf:
+        specifier: ^6.1.3
+        version: 6.1.3
+      ts-patch:
+        specifier: ^3.3.0
+        version: 3.3.0
+      typescript-eslint:
+        specifier: ^8.56.0
+        version: 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      typia:
+        specifier: ^11.0.3
+        version: 11.0.3(@types/node@25.2.3)(typescript@5.9.3)
+
+packages:
+
+  '@babel/runtime@7.28.6':
+    resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
+    engines: {node: '>=6.9.0'}
+
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.21.1':
+    resolution: {integrity: sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/config-helpers@0.4.2':
+    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.17.0':
+    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/eslintrc@3.3.3':
+    resolution: {integrity: sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@9.39.2':
+    resolution: {integrity: sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/object-schema@2.1.7':
+    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.4.1':
+    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@fastify/busboy@2.1.1':
+    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
+    engines: {node: '>=14'}
+
+  '@humanfs/core@0.19.1':
+    resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.7':
+    resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
+
+  '@inquirer/external-editor@1.0.3':
+    resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@isaacs/cliui@9.0.0':
+    resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
+    engines: {node: '>=18'}
+
+  '@marcrock22/eslint@https://codeload.github.com/marcrock22/eslintcf/tar.gz/df5c32a96ebd80f273b64398552548c5fef4dede':
+    resolution: {tarball: https://codeload.github.com/marcrock22/eslintcf/tar.gz/df5c32a96ebd80f273b64398552548c5fef4dede}
+    version: 1.0.0
+    peerDependencies:
+      '@eslint/js': ^9.17.0
+      '@stylistic/eslint-plugin': ^2.12.1
+      '@typescript-eslint/utils': ^8.19.1
+      eslint: ^9.17.0
+      eslint-plugin-perfectionist: ^4.6.0
+      typescript-eslint: ^8.19.1
+
+  '@napi-rs/canvas-android-arm64@0.1.93':
+    resolution: {integrity: sha512-xRIoOPFvneR29Dtq5d9p2AJbijDCFeV4jQ+5Ms/xVAXJVb8R0Jlu+pPr/SkhrG+Mouaml4roPSXugTIeRl6CMA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-darwin-arm64@0.1.93':
+    resolution: {integrity: sha512-daNDi76HN5grC6GXDmpxdfP+N2mQPd3sCfg62VyHwUuvbZh32P7R/IUjkzAxtYMtTza+Zvx9hfLJ3J7ENL6WMA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@0.1.93':
+    resolution: {integrity: sha512-1YfuNPIQLawsg/gSNdJRk4kQWUy9M/Gy8FGsOI79nhQEJ2PZdqpSPl5UNzf4elfuNXuVbEbmmjP68EQdUunDuQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.93':
+    resolution: {integrity: sha512-8kEkOQPZjuyHjupvXExuJZiuiVNecdABGq3DLI7aO1EvQFOOlWMm2d/8Q5qXdV73Tn+nu3m16+kPajsN1oJefQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.93':
+    resolution: {integrity: sha512-qIKLKkBkYSyWSYAoDThoxf5y1gr4X0g7W8rDU7d2HDeAAcotdVHUwuKkMeNe6+5VNk7/95EIhbslQjSxiCu32g==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.93':
+    resolution: {integrity: sha512-mAwQBGM3qArS9XEO21AK4E1uGvCuUCXjhIZk0dlVvs49MQ6wAAuCkYKNFpSKeSicKrLWwBMfgWX4qZoPh+M00A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.93':
+    resolution: {integrity: sha512-kaIH5MpPzOZfkM+QMsBxGdM9jlJT+N+fwz2IEaju/S+DL65E5TgPOx4QcD5dQ8vsMxlak6uDrudBc4ns5xzZCw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.93':
+    resolution: {integrity: sha512-KtMZJqYWvOSeW5w3VSV2f5iGnwNdKJm4gwgVid4xNy1NFi+NJSyuglA1lX1u4wIPxizyxh8OW5c5Usf6oSOMNQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.93':
+    resolution: {integrity: sha512-qRZhOvlDBooRLX6V3/t9X9B+plZK+OrPLgfFixu0A1RO/3VHbubOknfnMnocSDAqk/L6cRyKI83VP2ciR9UO7w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.93':
+    resolution: {integrity: sha512-um5XE44vF8bjkQEsH2iRSUP9fDeQGYbn/qjM/v4whXG83qsqapAXlOPOQqSARZB1SiNvPUAuXoRsJLlKFmAEFw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.93':
+    resolution: {integrity: sha512-maHlizZgmKsAPJwjwBZMnsWfq3Ca9QutoteQwKe7YqsmbECoylrLCCOGCDOredstW4BRWqRTfCl6NJaVVeAQvQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas@0.1.93':
+    resolution: {integrity: sha512-unVFo8CUlUeJCCxt50+j4yy91NF4x6n9zdGcvEsOFAWzowtZm3mgx8X2D7xjwV0cFSfxmpGPoe+JS77uzeFsxg==}
+    engines: {node: '>= 10'}
+
+  '@prisma/client@6.19.2':
+    resolution: {integrity: sha512-gR2EMvfK/aTxsuooaDA32D8v+us/8AAet+C3J1cc04SW35FPdZYgLF+iN4NDLUgAaUGTKdAB0CYenu1TAgGdMg==}
+    engines: {node: '>=18.18'}
+    peerDependencies:
+      prisma: '*'
+      typescript: '>=5.1.0'
+    peerDependenciesMeta:
+      prisma:
+        optional: true
+      typescript:
+        optional: true
+
+  '@prisma/config@6.19.2':
+    resolution: {integrity: sha512-kadBGDl+aUswv/zZMk9Mx0C8UZs1kjao8H9/JpI4Wh4SHZaM7zkTwiKn/iFLfRg+XtOAo/Z/c6pAYhijKl0nzQ==}
+
+  '@prisma/debug@6.19.2':
+    resolution: {integrity: sha512-lFnEZsLdFLmEVCVNdskLDCL8Uup41GDfU0LUfquw+ercJC8ODTuL0WNKgOKmYxCJVvFwf0OuZBzW99DuWmoH2A==}
+
+  '@prisma/engines-version@7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7':
+    resolution: {integrity: sha512-03bgb1VD5gvuumNf+7fVGBzfpJPjmqV423l/WxsWk2cNQ42JD0/SsFBPhN6z8iAvdHs07/7ei77SKu7aZfq8bA==}
+
+  '@prisma/engines@6.19.2':
+    resolution: {integrity: sha512-TTkJ8r+uk/uqczX40wb+ODG0E0icVsMgwCTyTHXehaEfb0uo80M9g1aW1tEJrxmFHeOZFXdI2sTA1j1AgcHi4A==}
+
+  '@prisma/fetch-engine@6.19.2':
+    resolution: {integrity: sha512-h4Ff4Pho+SR1S8XerMCC12X//oY2bG3Iug/fUnudfcXEUnIeRiBdXHFdGlGOgQ3HqKgosTEhkZMvGM9tWtYC+Q==}
+
+  '@prisma/get-platform@6.19.2':
+    resolution: {integrity: sha512-PGLr06JUSTqIvztJtAzIxOwtWKtJm5WwOG6xpsgD37Rc84FpfUBGLKz65YpJBGtkRQGXTYEFie7pYALocC3MtA==}
+
+  '@redis/client@5.11.0':
+    resolution: {integrity: sha512-GHoprlNQD51Xq2Ztd94HHV94MdFZQ3CVrpA04Fz8MVoHM0B7SlbmPEVIjwTbcv58z8QyjnrOuikS0rWF03k5dQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@node-rs/xxhash': ^1.1.0
+    peerDependenciesMeta:
+      '@node-rs/xxhash':
+        optional: true
+
+  '@resvg/resvg-js-android-arm-eabi@2.6.2':
+    resolution: {integrity: sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+
+  '@resvg/resvg-js-android-arm64@2.6.2':
+    resolution: {integrity: sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@resvg/resvg-js-darwin-arm64@2.6.2':
+    resolution: {integrity: sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@resvg/resvg-js-darwin-x64@2.6.2':
+    resolution: {integrity: sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@resvg/resvg-js-linux-arm-gnueabihf@2.6.2':
+    resolution: {integrity: sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@resvg/resvg-js-linux-arm64-gnu@2.6.2':
+    resolution: {integrity: sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@resvg/resvg-js-linux-arm64-musl@2.6.2':
+    resolution: {integrity: sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@resvg/resvg-js-linux-x64-gnu@2.6.2':
+    resolution: {integrity: sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@resvg/resvg-js-linux-x64-musl@2.6.2':
+    resolution: {integrity: sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
+    resolution: {integrity: sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@resvg/resvg-js-win32-ia32-msvc@2.6.2':
+    resolution: {integrity: sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@resvg/resvg-js-win32-x64-msvc@2.6.2':
+    resolution: {integrity: sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@resvg/resvg-js@2.6.2':
+    resolution: {integrity: sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==}
+    engines: {node: '>= 10'}
+
+  '@samchon/openapi@6.0.1':
+    resolution: {integrity: sha512-+nkznmCf/6YavoVkvWg60YoC0UbXY/oK9uMZReyrFcIcXecf+YoWmOLUg+TlgHi+h+6DPgRy6zRkZfiRd3uRnA==}
+
+  '@shuding/opentype.js@1.4.0-beta.0':
+    resolution: {integrity: sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==}
+    engines: {node: '>= 8.0.0'}
+    hasBin: true
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@stylistic/eslint-plugin@2.13.0':
+    resolution: {integrity: sha512-RnO1SaiCFHn666wNz2QfZEFxvmiNRqhzaMXHXxXXKt+MEP7aajlPxUSMIQpKAaJfverpovEYqjBOXDq6dDcaOQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: '>=8.40.0'
+
+  '@top-gg/sdk@3.1.6':
+    resolution: {integrity: sha512-qWWYDKAwJHaKaA/5EyLYMzfR76MwCbmKVMSXTPMd9FZFPHuLWJHO+m7Q8dWpWtcnunHa6evRAwlB3p83cht7Ww==}
+
+  '@types/bun@1.3.9':
+    resolution: {integrity: sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@25.2.3':
+    resolution: {integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==}
+
+  '@typescript-eslint/eslint-plugin@8.56.0':
+    resolution: {integrity: sha512-lRyPDLzNCuae71A3t9NEINBiTn7swyOhvUj3MyUOxb8x6g6vPEFoOU+ZRmGMusNC3X3YMhqMIX7i8ShqhT74Pw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.56.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/parser@8.56.0':
+    resolution: {integrity: sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/project-service@8.56.0':
+    resolution: {integrity: sha512-M3rnyL1vIQOMeWxTWIW096/TtVP+8W3p/XnaFflhmcFp+U4zlxUxWj4XwNs6HbDeTtN4yun0GNTTDBw/SvufKg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/scope-manager@8.56.0':
+    resolution: {integrity: sha512-7UiO/XwMHquH+ZzfVCfUNkIXlp/yQjjnlYUyYz7pfvlK3/EyyN6BK+emDmGNyQLBtLGaYrTAI6KOw8tFucWL2w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.56.0':
+    resolution: {integrity: sha512-bSJoIIt4o3lKXD3xmDh9chZcjCz5Lk8xS7Rxn+6l5/pKrDpkCwtQNQQwZ2qRPk7TkUYhrq3WPIHXOXlbXP0itg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/type-utils@8.56.0':
+    resolution: {integrity: sha512-qX2L3HWOU2nuDs6GzglBeuFXviDODreS58tLY/BALPC7iu3Fa+J7EOTwnX9PdNBxUI7Uh0ntP0YWGnxCkXzmfA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/types@8.56.0':
+    resolution: {integrity: sha512-DBsLPs3GsWhX5HylbP9HNG15U0bnwut55Lx12bHB9MpXxQ+R5GC8MwQe+N1UFXxAeQDvEsEDY6ZYwX03K7Z6HQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.56.0':
+    resolution: {integrity: sha512-ex1nTUMWrseMltXUHmR2GAQ4d+WjkZCT4f+4bVsps8QEdh0vlBsaCokKTPlnqBFqqGaxilDNJG7b8dolW2m43Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/utils@8.56.0':
+    resolution: {integrity: sha512-RZ3Qsmi2nFGsS+n+kjLAYDPVlrzf7UhTffrDIKr+h2yzAlYP/y5ZulU0yeDEPItos2Ph46JAL5P/On3pe7kDIQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/visitor-keys@8.56.0':
+    resolution: {integrity: sha512-q+SL+b+05Ud6LbEE35qe4A99P+htKTKVbyiNEe45eCbJFyh/HVK9QXwlrbz+Q4L8SOW4roxSVwXYj4DMBT7Ieg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.12.6:
+    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  ansi-escapes@4.3.2:
+    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  array-timsort@1.0.3:
+    resolution: {integrity: sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  balanced-match@4.0.2:
+    resolution: {integrity: sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg==}
+    engines: {node: 20 || >=22}
+
+  base64-js@0.0.8:
+    resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
+    engines: {node: '>= 0.4'}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  brace-expansion@1.1.12:
+    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+
+  brace-expansion@2.0.2:
+    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  brace-expansion@5.0.2:
+    resolution: {integrity: sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==}
+    engines: {node: 20 || >=22}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  bun-types@1.3.9:
+    resolution: {integrity: sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg==}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  c12@3.1.0:
+    resolution: {integrity: sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==}
+    peerDependencies:
+      magicast: ^0.3.5
+    peerDependenciesMeta:
+      magicast:
+        optional: true
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  camelize@1.0.1:
+    resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  chardet@2.1.1:
+    resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+
+  cheerio-select@2.1.0:
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
+
+  cheerio@1.2.0:
+    resolution: {integrity: sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==}
+    engines: {node: '>=20.18.1'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  citty@0.1.6:
+    resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
+
+  citty@0.2.1:
+    resolution: {integrity: sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==}
+
+  cli-cursor@3.1.0:
+    resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
+    engines: {node: '>=8'}
+
+  cli-spinners@2.9.2:
+    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
+    engines: {node: '>=6'}
+
+  cli-width@3.0.0:
+    resolution: {integrity: sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==}
+    engines: {node: '>= 10'}
+
+  clone@1.0.4:
+    resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
+    engines: {node: '>=0.8'}
+
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
+
+  comment-json@4.5.1:
+    resolution: {integrity: sha512-taEtr3ozUmOB7it68Jll7s0Pwm+aoiHyXKrEC8SEodL4rNpdfDLqa7PfBlrgFoCNNdR8ImL+muti5IGvktJAAg==}
+    engines: {node: '>= 6'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  confbox@0.2.4:
+    resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  css-background-parser@0.1.0:
+    resolution: {integrity: sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==}
+
+  css-box-shadow@1.0.0-3:
+    resolution: {integrity: sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==}
+
+  css-color-keywords@1.0.0:
+    resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==}
+    engines: {node: '>=4'}
+
+  css-gradient-parser@0.0.17:
+    resolution: {integrity: sha512-w2Xy9UMMwlKtou0vlRnXvWglPAceXCTtcmVSo8ZBUvqCV5aXEFP/PC6d+I464810I9FT++UACwTD5511bmGPUg==}
+    engines: {node: '>=16'}
+
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
+  css-to-react-native@3.2.0:
+    resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  deepmerge-ts@7.1.5:
+    resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
+    engines: {node: '>=16.0.0'}
+
+  defaults@1.0.4:
+    resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
+
+  defu@6.1.4:
+    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
+  destr@2.0.5:
+    resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
+
+  didyoumean2@7.0.4:
+    resolution: {integrity: sha512-+yW4SNY7W2DOWe2Jx5H4c2qMTFbLGM6wIyoDPkAPy66X+sD1KfYjBPAIWPVsYqMxelflaMQCloZDudELIPhLqA==}
+    engines: {node: ^18.12.0 || >=20.9.0}
+
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  drange@1.1.1:
+    resolution: {integrity: sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA==}
+    engines: {node: '>=4'}
+
+  effect@3.18.4:
+    resolution: {integrity: sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==}
+
+  emoji-regex-xs@2.0.1:
+    resolution: {integrity: sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==}
+    engines: {node: '>=10.0.0'}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  empathic@2.0.0:
+    resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
+    engines: {node: '>=14'}
+
+  encoding-sniffer@0.2.1:
+    resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  escape-string-regexp@1.0.5:
+    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
+    engines: {node: '>=0.8.0'}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-plugin-perfectionist@4.15.1:
+    resolution: {integrity: sha512-MHF0cBoOG0XyBf7G0EAFCuJJu4I18wy0zAoT1OHfx2o6EOx1EFTIzr2HGeuZa1kDcusoX0xJ9V7oZmaeFd773Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    peerDependencies:
+      eslint: '>=8.45.0'
+
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@5.0.0:
+    resolution: {integrity: sha512-A0XeIi7CXU7nPlfHS9loMYEKxUaONu/hTEzHTGba9Huu94Cq1hPivf+DE5erJozZOky0LfvXAyrV/tcswpLI0Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@9.39.2:
+    resolution: {integrity: sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
+  exsolve@1.0.8:
+    resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
+
+  fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fastest-levenshtein@1.0.16:
+    resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
+    engines: {node: '>= 4.9.1'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fflate@0.7.4:
+    resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
+
+  figures@3.2.0:
+    resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
+    engines: {node: '>=8'}
+
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.3.3:
+    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  giget@2.0.0:
+    resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
+    hasBin: true
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  glob@13.0.5:
+    resolution: {integrity: sha512-BzXxZg24Ibra1pbQ/zE7Kys4Ua1ks7Bn6pKLkVPZ9FZe4JQS6/Q7ef3LG1H+k7lUf5l4T3PLSyYyYJVYUvfgTw==}
+    engines: {node: 20 || >=22}
+
+  global-prefix@4.0.0:
+    resolution: {integrity: sha512-w0Uf9Y9/nyHinEk5vMJKRie+wa4kR5hmDbEhGGds/kG1PwGLLHKRoNMeJOyCQjjBkANlnScqgzcFwGHgmgLkVA==}
+    engines: {node: '>=16'}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hex-rgb@4.3.0:
+    resolution: {integrity: sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==}
+    engines: {node: '>=6'}
+
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  iconv-lite@0.4.24:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@4.1.3:
+    resolution: {integrity: sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  inquirer@8.2.7:
+    resolution: {integrity: sha512-UjOaSel/iddGZJ5xP/Eixh6dY1XghiBw4XK13rCCIJcJfyhhoul/7KhLLUGtebEj6GDYM6Vnx/mVsjx2L/mFIA==}
+    engines: {node: '>=12.0.0'}
+
+  is-core-module@2.16.1:
+    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
+    engines: {node: '>= 0.4'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-interactive@1.0.0:
+    resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
+    engines: {node: '>=8'}
+
+  is-unicode-supported@0.1.0:
+    resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
+    engines: {node: '>=10'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isexe@3.1.5:
+    resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
+    engines: {node: '>=18'}
+
+  jackspeak@4.2.3:
+    resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
+    engines: {node: 20 || >=22}
+
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+
+  linebreak@1.1.0:
+    resolution: {integrity: sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
+  lodash.deburr@4.1.0:
+    resolution: {integrity: sha512-m/M1U1f3ddMCs6Hq2tAsYThTBDaAKFDX3dwDo97GEYzamXi9SqUpjWi/Rrj/gf3X2n8ktwgZrlP1z6E3v/IExQ==}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash@4.17.23:
+    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+
+  log-symbols@4.1.0:
+    resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
+    engines: {node: '>=10'}
+
+  lru-cache@11.2.6:
+    resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
+    engines: {node: 20 || >=22}
+
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
+
+  minimatch@10.2.1:
+    resolution: {integrity: sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==}
+    engines: {node: 20 || >=22}
+
+  minimatch@3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+
+  minimatch@9.0.5:
+    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mute-stream@0.0.8:
+    resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  natural-orderby@5.0.0:
+    resolution: {integrity: sha512-kKHJhxwpR/Okycz4HhQKKlhWe4ASEfPgkSWNmKFHd7+ezuQlxkA5cM3+XkBPvm1gmHen3w53qsYAv+8GwRrBlg==}
+    engines: {node: '>=18'}
+
+  node-fetch-native@1.6.7:
+    resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
+  nypm@0.6.5:
+    resolution: {integrity: sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  ohash@2.0.11:
+    resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
+
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  ora@5.4.1:
+    resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
+    engines: {node: '>=10'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  package-manager-detector@0.2.11:
+    resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
+
+  pako@0.2.9:
+    resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  parse-css-color@0.2.1:
+    resolution: {integrity: sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==}
+
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
+
+  parse5-parser-stream@7.1.2:
+    resolution: {integrity: sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@2.0.1:
+    resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
+    engines: {node: 20 || >=22}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  perfect-debounce@1.0.0:
+    resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  pkg-types@2.3.0:
+    resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
+  prisma@6.19.2:
+    resolution: {integrity: sha512-XTKeKxtQElcq3U9/jHyxSPgiRgeYDKxWTPOf6NkXA0dNj5j40MfEsZkMbyNpwDWCUv7YBFUl7I2VK/6ALbmhEg==}
+    engines: {node: '>=18.18'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.1.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  quansync@0.2.11:
+    resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
+
+  randexp@0.5.3:
+    resolution: {integrity: sha512-U+5l2KrcMNOUPYvazA3h5ekF80FHTUG+87SEAmHZmolh1M+i/WyTCxVzmi+tidIa1tM4BSe8g2Y/D3loWDjj+w==}
+    engines: {node: '>=4'}
+
+  raw-body@2.5.3:
+    resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
+    engines: {node: '>= 0.8'}
+
+  rc9@2.1.2:
+    resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  resolve@1.22.11:
+    resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
+  restore-cursor@3.1.0:
+    resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
+    engines: {node: '>=8'}
+
+  ret@0.2.2:
+    resolution: {integrity: sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==}
+    engines: {node: '>=4'}
+
+  rimraf@6.1.3:
+    resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
+    engines: {node: 20 || >=22}
+    hasBin: true
+
+  run-async@2.4.1:
+    resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
+    engines: {node: '>=0.12.0'}
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  satori-html@0.3.2:
+    resolution: {integrity: sha512-wjTh14iqADFKDK80e51/98MplTGfxz2RmIzh0GqShlf4a67+BooLywF17TvJPD6phO0Hxm7Mf1N5LtRYvdkYRA==}
+
+  satori@0.19.2:
+    resolution: {integrity: sha512-71plFHWcq6WJBM5sf/n0eHOmTBiKLUB/G8du7SmLTTLHKEKrV3TPHGKcEVIoyjnbhnjvu9HhLyF9MATB/zzL7g==}
+    engines: {node: '>=16'}
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  seyfert@4.2.2-dev-22071590650.0:
+    resolution: {integrity: sha512-R6Fe2owhUBn92lO1+oL9MvxTrj4O/IpzrDacuhn9bjHUQKETuTQkF5s5SF11Ev8Q/UVD2WiQoZ5fruy5/r6AWQ==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string.prototype.codepointat@0.2.1:
+    resolution: {integrity: sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+
+  through@2.3.8:
+    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
+
+  tiny-inflate@1.0.3:
+    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
+
+  tinyexec@1.0.2:
+    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
+  ts-api-utils@2.4.0:
+    resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
+  ts-patch@3.3.0:
+    resolution: {integrity: sha512-zAOzDnd5qsfEnjd9IGy1IRuvA7ygyyxxdxesbhMdutt8AHFjD8Vw8hU2rMF89HX1BKRWFYqKHrO8Q6lw0NeUZg==}
+    hasBin: true
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
+  type-fest@0.21.3:
+    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
+    engines: {node: '>=10'}
+
+  typescript-eslint@8.56.0:
+    resolution: {integrity: sha512-c7toRLrotJ9oixgdW7liukZpsnq5CZ7PuKztubGYlNppuTqhIoWfhgHo/7EU0v06gS2l/x0i2NEFK1qMIf0rIg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  typia@11.0.3:
+    resolution: {integrity: sha512-L7x7WzOCpFyNCauWl6VYJVEG9EHZi5EPNBRzxTO1luaLCd6WEDf+xrJNT+hMZ8U+0X7hCsR1EUpi29LdHhvCvA==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=4.8.0 <5.10.0'
+
+  ultrahtml@1.6.0:
+    resolution: {integrity: sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw==}
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  undici@5.29.0:
+    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
+    engines: {node: '>=14.0'}
+
+  undici@7.22.0:
+    resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
+    engines: {node: '>=20.18.1'}
+
+  unicode-trie@2.0.0:
+    resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  wcwidth@1.0.1:
+    resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  which@4.0.0:
+    resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
+    engines: {node: ^16.13.0 || >=18.0.0}
+    hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
+  yoga-layout@3.2.1:
+    resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
+
+snapshots:
+
+  '@babel/runtime@7.28.6': {}
+
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@2.6.1))':
+    dependencies:
+      eslint: 9.39.2(jiti@2.6.1)
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.21.1':
+    dependencies:
+      '@eslint/object-schema': 2.1.7
+      debug: 4.4.3
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.4.2':
+    dependencies:
+      '@eslint/core': 0.17.0
+
+  '@eslint/core@0.17.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/eslintrc@3.3.3':
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.4.3
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@9.39.2': {}
+
+  '@eslint/object-schema@2.1.7': {}
+
+  '@eslint/plugin-kit@0.4.1':
+    dependencies:
+      '@eslint/core': 0.17.0
+      levn: 0.4.1
+
+  '@fastify/busboy@2.1.1': {}
+
+  '@humanfs/core@0.19.1': {}
+
+  '@humanfs/node@0.16.7':
+    dependencies:
+      '@humanfs/core': 0.19.1
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
+
+  '@inquirer/external-editor@1.0.3(@types/node@25.2.3)':
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 25.2.3
+
+  '@isaacs/cliui@9.0.0': {}
+
+  '@marcrock22/eslint@https://codeload.github.com/marcrock22/eslintcf/tar.gz/df5c32a96ebd80f273b64398552548c5fef4dede(@eslint/js@9.39.2)(@stylistic/eslint-plugin@2.13.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(@typescript-eslint/utils@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-perfectionist@4.15.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript-eslint@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))':
+    dependencies:
+      '@eslint/js': 9.39.2
+      '@stylistic/eslint-plugin': 2.13.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.2(jiti@2.6.1)
+      eslint-plugin-perfectionist: 4.15.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      typescript-eslint: 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+
+  '@napi-rs/canvas-android-arm64@0.1.93':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@0.1.93':
+    optional: true
+
+  '@napi-rs/canvas-darwin-x64@0.1.93':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.93':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.93':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.93':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.93':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.93':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.93':
+    optional: true
+
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.93':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.93':
+    optional: true
+
+  '@napi-rs/canvas@0.1.93':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 0.1.93
+      '@napi-rs/canvas-darwin-arm64': 0.1.93
+      '@napi-rs/canvas-darwin-x64': 0.1.93
+      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.93
+      '@napi-rs/canvas-linux-arm64-gnu': 0.1.93
+      '@napi-rs/canvas-linux-arm64-musl': 0.1.93
+      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.93
+      '@napi-rs/canvas-linux-x64-gnu': 0.1.93
+      '@napi-rs/canvas-linux-x64-musl': 0.1.93
+      '@napi-rs/canvas-win32-arm64-msvc': 0.1.93
+      '@napi-rs/canvas-win32-x64-msvc': 0.1.93
+
+  '@prisma/client@6.19.2(prisma@6.19.2(typescript@5.9.3))(typescript@5.9.3)':
+    optionalDependencies:
+      prisma: 6.19.2(typescript@5.9.3)
+      typescript: 5.9.3
+
+  '@prisma/config@6.19.2':
+    dependencies:
+      c12: 3.1.0
+      deepmerge-ts: 7.1.5
+      effect: 3.18.4
+      empathic: 2.0.0
+    transitivePeerDependencies:
+      - magicast
+
+  '@prisma/debug@6.19.2': {}
+
+  '@prisma/engines-version@7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7': {}
+
+  '@prisma/engines@6.19.2':
+    dependencies:
+      '@prisma/debug': 6.19.2
+      '@prisma/engines-version': 7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7
+      '@prisma/fetch-engine': 6.19.2
+      '@prisma/get-platform': 6.19.2
+
+  '@prisma/fetch-engine@6.19.2':
+    dependencies:
+      '@prisma/debug': 6.19.2
+      '@prisma/engines-version': 7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7
+      '@prisma/get-platform': 6.19.2
+
+  '@prisma/get-platform@6.19.2':
+    dependencies:
+      '@prisma/debug': 6.19.2
+
+  '@redis/client@5.11.0':
+    dependencies:
+      cluster-key-slot: 1.1.2
+
+  '@resvg/resvg-js-android-arm-eabi@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-android-arm64@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-darwin-arm64@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-darwin-x64@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-arm-gnueabihf@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-arm64-gnu@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-arm64-musl@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-x64-gnu@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-x64-musl@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-win32-ia32-msvc@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-win32-x64-msvc@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js@2.6.2':
+    optionalDependencies:
+      '@resvg/resvg-js-android-arm-eabi': 2.6.2
+      '@resvg/resvg-js-android-arm64': 2.6.2
+      '@resvg/resvg-js-darwin-arm64': 2.6.2
+      '@resvg/resvg-js-darwin-x64': 2.6.2
+      '@resvg/resvg-js-linux-arm-gnueabihf': 2.6.2
+      '@resvg/resvg-js-linux-arm64-gnu': 2.6.2
+      '@resvg/resvg-js-linux-arm64-musl': 2.6.2
+      '@resvg/resvg-js-linux-x64-gnu': 2.6.2
+      '@resvg/resvg-js-linux-x64-musl': 2.6.2
+      '@resvg/resvg-js-win32-arm64-msvc': 2.6.2
+      '@resvg/resvg-js-win32-ia32-msvc': 2.6.2
+      '@resvg/resvg-js-win32-x64-msvc': 2.6.2
+
+  '@samchon/openapi@6.0.1': {}
+
+  '@shuding/opentype.js@1.4.0-beta.0':
+    dependencies:
+      fflate: 0.7.4
+      string.prototype.codepointat: 0.2.1
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@stylistic/eslint-plugin@2.13.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/utils': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.2(jiti@2.6.1)
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      estraverse: 5.3.0
+      picomatch: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@top-gg/sdk@3.1.6':
+    dependencies:
+      raw-body: 2.5.3
+      undici: 5.29.0
+
+  '@types/bun@1.3.9':
+    dependencies:
+      bun-types: 1.3.9
+
+  '@types/estree@1.0.8': {}
+
+  '@types/json-schema@7.0.15': {}
+
+  '@types/node@25.2.3':
+    dependencies:
+      undici-types: 7.16.0
+
+  '@typescript-eslint/eslint-plugin@8.56.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.56.0
+      '@typescript-eslint/type-utils': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.56.0
+      eslint: 9.39.2(jiti@2.6.1)
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.4.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.56.0
+      '@typescript-eslint/types': 8.56.0
+      '@typescript-eslint/typescript-estree': 8.56.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.56.0
+      debug: 4.4.3
+      eslint: 9.39.2(jiti@2.6.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.56.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.56.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.56.0
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.56.0':
+    dependencies:
+      '@typescript-eslint/types': 8.56.0
+      '@typescript-eslint/visitor-keys': 8.56.0
+
+  '@typescript-eslint/tsconfig-utils@8.56.0(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@typescript-eslint/type-utils@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.56.0
+      '@typescript-eslint/typescript-estree': 8.56.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      debug: 4.4.3
+      eslint: 9.39.2(jiti@2.6.1)
+      ts-api-utils: 2.4.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.56.0': {}
+
+  '@typescript-eslint/typescript-estree@8.56.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.56.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.56.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.56.0
+      '@typescript-eslint/visitor-keys': 8.56.0
+      debug: 4.4.3
+      minimatch: 9.0.5
+      semver: 7.7.4
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.4.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
+      '@typescript-eslint/scope-manager': 8.56.0
+      '@typescript-eslint/types': 8.56.0
+      '@typescript-eslint/typescript-estree': 8.56.0(typescript@5.9.3)
+      eslint: 9.39.2(jiti@2.6.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.56.0':
+    dependencies:
+      '@typescript-eslint/types': 8.56.0
+      eslint-visitor-keys: 5.0.0
+
+  acorn-jsx@5.3.2(acorn@8.15.0):
+    dependencies:
+      acorn: 8.15.0
+
+  acorn@8.15.0: {}
+
+  ajv@6.12.6:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  ansi-escapes@4.3.2:
+    dependencies:
+      type-fest: 0.21.3
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  argparse@2.0.1: {}
+
+  array-timsort@1.0.3: {}
+
+  balanced-match@1.0.2: {}
+
+  balanced-match@4.0.2:
+    dependencies:
+      jackspeak: 4.2.3
+
+  base64-js@0.0.8: {}
+
+  base64-js@1.5.1: {}
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  boolbase@1.0.0: {}
+
+  brace-expansion@1.1.12:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@2.0.2:
+    dependencies:
+      balanced-match: 1.0.2
+
+  brace-expansion@5.0.2:
+    dependencies:
+      balanced-match: 4.0.2
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  bun-types@1.3.9:
+    dependencies:
+      '@types/node': 25.2.3
+
+  bytes@3.1.2: {}
+
+  c12@3.1.0:
+    dependencies:
+      chokidar: 4.0.3
+      confbox: 0.2.4
+      defu: 6.1.4
+      dotenv: 16.6.1
+      exsolve: 1.0.8
+      giget: 2.0.0
+      jiti: 2.6.1
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 1.0.0
+      pkg-types: 2.3.0
+      rc9: 2.1.2
+
+  callsites@3.1.0: {}
+
+  camelize@1.0.1: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  chardet@2.1.1: {}
+
+  cheerio-select@2.1.0:
+    dependencies:
+      boolbase: 1.0.0
+      css-select: 5.2.2
+      css-what: 6.2.2
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+
+  cheerio@1.2.0:
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      encoding-sniffer: 0.2.1
+      htmlparser2: 10.1.0
+      parse5: 7.3.0
+      parse5-htmlparser2-tree-adapter: 7.1.0
+      parse5-parser-stream: 7.1.2
+      undici: 7.22.0
+      whatwg-mimetype: 4.0.0
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  citty@0.1.6:
+    dependencies:
+      consola: 3.4.2
+
+  citty@0.2.1: {}
+
+  cli-cursor@3.1.0:
+    dependencies:
+      restore-cursor: 3.1.0
+
+  cli-spinners@2.9.2: {}
+
+  cli-width@3.0.0: {}
+
+  clone@1.0.4: {}
+
+  cluster-key-slot@1.1.2: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  commander@10.0.1: {}
+
+  comment-json@4.5.1:
+    dependencies:
+      array-timsort: 1.0.3
+      core-util-is: 1.0.3
+      esprima: 4.0.1
+
+  concat-map@0.0.1: {}
+
+  confbox@0.2.4: {}
+
+  consola@3.4.2: {}
+
+  core-util-is@1.0.3: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  css-background-parser@0.1.0: {}
+
+  css-box-shadow@1.0.0-3: {}
+
+  css-color-keywords@1.0.0: {}
+
+  css-gradient-parser@0.0.17: {}
+
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
+  css-to-react-native@3.2.0:
+    dependencies:
+      camelize: 1.0.1
+      css-color-keywords: 1.0.0
+      postcss-value-parser: 4.2.0
+
+  css-what@6.2.2: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-is@0.1.4: {}
+
+  deepmerge-ts@7.1.5: {}
+
+  defaults@1.0.4:
+    dependencies:
+      clone: 1.0.4
+
+  defu@6.1.4: {}
+
+  depd@2.0.0: {}
+
+  destr@2.0.5: {}
+
+  didyoumean2@7.0.4:
+    dependencies:
+      '@babel/runtime': 7.28.6
+      fastest-levenshtein: 1.0.16
+      lodash.deburr: 4.1.0
+
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
+  dotenv@16.6.1: {}
+
+  drange@1.1.1: {}
+
+  effect@3.18.4:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 3.23.2
+
+  emoji-regex-xs@2.0.1: {}
+
+  emoji-regex@8.0.0: {}
+
+  empathic@2.0.0: {}
+
+  encoding-sniffer@0.2.1:
+    dependencies:
+      iconv-lite: 0.6.3
+      whatwg-encoding: 3.1.1
+
+  entities@4.5.0: {}
+
+  entities@6.0.1: {}
+
+  entities@7.0.1: {}
+
+  escape-html@1.0.3: {}
+
+  escape-string-regexp@1.0.5: {}
+
+  escape-string-regexp@4.0.0: {}
+
+  eslint-plugin-perfectionist@4.15.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/types': 8.56.0
+      '@typescript-eslint/utils': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.2(jiti@2.6.1)
+      natural-orderby: 5.0.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  eslint-scope@8.4.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.1: {}
+
+  eslint-visitor-keys@5.0.0: {}
+
+  eslint@9.39.2(jiti@2.6.1):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.21.1
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.3
+      '@eslint/js': 9.39.2
+      '@eslint/plugin-kit': 0.4.1
+      '@humanfs/node': 0.16.7
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.8
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.6.1
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
+      eslint-visitor-keys: 4.2.1
+
+  esprima@4.0.1: {}
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
+  esutils@2.0.3: {}
+
+  exsolve@1.0.8: {}
+
+  fast-check@3.23.2:
+    dependencies:
+      pure-rand: 6.1.0
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
+  fastest-levenshtein@1.0.16: {}
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  fflate@0.7.4: {}
+
+  figures@3.2.0:
+    dependencies:
+      escape-string-regexp: 1.0.5
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.3.3
+      keyv: 4.5.4
+
+  flatted@3.3.3: {}
+
+  function-bind@1.1.2: {}
+
+  giget@2.0.0:
+    dependencies:
+      citty: 0.1.6
+      consola: 3.4.2
+      defu: 6.1.4
+      node-fetch-native: 1.6.7
+      nypm: 0.6.5
+      pathe: 2.0.3
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob@13.0.5:
+    dependencies:
+      minimatch: 10.2.1
+      minipass: 7.1.2
+      path-scurry: 2.0.1
+
+  global-prefix@4.0.0:
+    dependencies:
+      ini: 4.1.3
+      kind-of: 6.0.3
+      which: 4.0.0
+
+  globals@14.0.0: {}
+
+  has-flag@4.0.0: {}
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hex-rgb@4.3.0: {}
+
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  ieee754@1.2.1: {}
+
+  ignore@5.3.2: {}
+
+  ignore@7.0.5: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  imurmurhash@0.1.4: {}
+
+  inherits@2.0.4: {}
+
+  ini@4.1.3: {}
+
+  inquirer@8.2.7(@types/node@25.2.3):
+    dependencies:
+      '@inquirer/external-editor': 1.0.3(@types/node@25.2.3)
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      cli-cursor: 3.1.0
+      cli-width: 3.0.0
+      figures: 3.2.0
+      lodash: 4.17.23
+      mute-stream: 0.0.8
+      ora: 5.4.1
+      run-async: 2.4.1
+      rxjs: 7.8.2
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      through: 2.3.8
+      wrap-ansi: 6.2.0
+    transitivePeerDependencies:
+      - '@types/node'
+
+  is-core-module@2.16.1:
+    dependencies:
+      hasown: 2.0.2
+
+  is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-interactive@1.0.0: {}
+
+  is-unicode-supported@0.1.0: {}
+
+  isexe@2.0.0: {}
+
+  isexe@3.1.5: {}
+
+  jackspeak@4.2.3:
+    dependencies:
+      '@isaacs/cliui': 9.0.0
+
+  jiti@2.6.1: {}
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  kind-of@6.0.3: {}
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+
+  linebreak@1.1.0:
+    dependencies:
+      base64-js: 0.0.8
+      unicode-trie: 2.0.0
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
+  lodash.deburr@4.1.0: {}
+
+  lodash.merge@4.6.2: {}
+
+  lodash@4.17.23: {}
+
+  log-symbols@4.1.0:
+    dependencies:
+      chalk: 4.1.2
+      is-unicode-supported: 0.1.0
+
+  lru-cache@11.2.6: {}
+
+  mimic-fn@2.1.0: {}
+
+  minimatch@10.2.1:
+    dependencies:
+      brace-expansion: 5.0.2
+
+  minimatch@3.1.2:
+    dependencies:
+      brace-expansion: 1.1.12
+
+  minimatch@9.0.5:
+    dependencies:
+      brace-expansion: 2.0.2
+
+  minimist@1.2.8: {}
+
+  minipass@7.1.2: {}
+
+  ms@2.1.3: {}
+
+  mute-stream@0.0.8: {}
+
+  natural-compare@1.4.0: {}
+
+  natural-orderby@5.0.0: {}
+
+  node-fetch-native@1.6.7: {}
+
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
+
+  nypm@0.6.5:
+    dependencies:
+      citty: 0.2.1
+      pathe: 2.0.3
+      tinyexec: 1.0.2
+
+  ohash@2.0.11: {}
+
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  ora@5.4.1:
+    dependencies:
+      bl: 4.1.0
+      chalk: 4.1.2
+      cli-cursor: 3.1.0
+      cli-spinners: 2.9.2
+      is-interactive: 1.0.0
+      is-unicode-supported: 0.1.0
+      log-symbols: 4.1.0
+      strip-ansi: 6.0.1
+      wcwidth: 1.0.1
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  package-json-from-dist@1.0.1: {}
+
+  package-manager-detector@0.2.11:
+    dependencies:
+      quansync: 0.2.11
+
+  pako@0.2.9: {}
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  parse-css-color@0.2.1:
+    dependencies:
+      color-name: 1.1.4
+      hex-rgb: 4.3.0
+
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    dependencies:
+      domhandler: 5.0.3
+      parse5: 7.3.0
+
+  parse5-parser-stream@7.1.2:
+    dependencies:
+      parse5: 7.3.0
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
+  path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
+
+  path-parse@1.0.7: {}
+
+  path-scurry@2.0.1:
+    dependencies:
+      lru-cache: 11.2.6
+      minipass: 7.1.2
+
+  pathe@2.0.3: {}
+
+  perfect-debounce@1.0.0: {}
+
+  picomatch@4.0.3: {}
+
+  pkg-types@2.3.0:
+    dependencies:
+      confbox: 0.2.4
+      exsolve: 1.0.8
+      pathe: 2.0.3
+
+  postcss-value-parser@4.2.0: {}
+
+  prelude-ls@1.2.1: {}
+
+  prisma@6.19.2(typescript@5.9.3):
+    dependencies:
+      '@prisma/config': 6.19.2
+      '@prisma/engines': 6.19.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - magicast
+
+  punycode@2.3.1: {}
+
+  pure-rand@6.1.0: {}
+
+  quansync@0.2.11: {}
+
+  randexp@0.5.3:
+    dependencies:
+      drange: 1.1.1
+      ret: 0.2.2
+
+  raw-body@2.5.3:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.4.24
+      unpipe: 1.0.0
+
+  rc9@2.1.2:
+    dependencies:
+      defu: 6.1.4
+      destr: 2.0.5
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
+  readdirp@4.1.2: {}
+
+  resolve-from@4.0.0: {}
+
+  resolve@1.22.11:
+    dependencies:
+      is-core-module: 2.16.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
+  restore-cursor@3.1.0:
+    dependencies:
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+
+  ret@0.2.2: {}
+
+  rimraf@6.1.3:
+    dependencies:
+      glob: 13.0.5
+      package-json-from-dist: 1.0.1
+
+  run-async@2.4.1: {}
+
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
+  safe-buffer@5.2.1: {}
+
+  safer-buffer@2.1.2: {}
+
+  satori-html@0.3.2:
+    dependencies:
+      ultrahtml: 1.6.0
+
+  satori@0.19.2:
+    dependencies:
+      '@shuding/opentype.js': 1.4.0-beta.0
+      css-background-parser: 0.1.0
+      css-box-shadow: 1.0.0-3
+      css-gradient-parser: 0.0.17
+      css-to-react-native: 3.2.0
+      emoji-regex-xs: 2.0.1
+      escape-html: 1.0.3
+      linebreak: 1.1.0
+      parse-css-color: 0.2.1
+      postcss-value-parser: 4.2.0
+      yoga-layout: 3.2.1
+
+  semver@7.7.4: {}
+
+  setprototypeof@1.2.0: {}
+
+  seyfert@4.2.2-dev-22071590650.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  signal-exit@3.0.7: {}
+
+  statuses@2.0.2: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string.prototype.codepointat@0.2.1: {}
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-json-comments@3.1.1: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-preserve-symlinks-flag@1.0.0: {}
+
+  through@2.3.8: {}
+
+  tiny-inflate@1.0.3: {}
+
+  tinyexec@1.0.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  toidentifier@1.0.1: {}
+
+  ts-api-utils@2.4.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
+  ts-patch@3.3.0:
+    dependencies:
+      chalk: 4.1.2
+      global-prefix: 4.0.0
+      minimist: 1.2.8
+      resolve: 1.22.11
+      semver: 7.7.4
+      strip-ansi: 6.0.1
+
+  tslib@2.8.1: {}
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
+  type-fest@0.21.3: {}
+
+  typescript-eslint@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.56.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.56.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.2(jiti@2.6.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  typescript@5.9.3: {}
+
+  typia@11.0.3(@types/node@25.2.3)(typescript@5.9.3):
+    dependencies:
+      '@samchon/openapi': 6.0.1
+      '@standard-schema/spec': 1.1.0
+      commander: 10.0.1
+      comment-json: 4.5.1
+      inquirer: 8.2.7(@types/node@25.2.3)
+      package-manager-detector: 0.2.11
+      randexp: 0.5.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+
+  ultrahtml@1.6.0: {}
+
+  undici-types@7.16.0: {}
+
+  undici@5.29.0:
+    dependencies:
+      '@fastify/busboy': 2.1.1
+
+  undici@7.22.0: {}
+
+  unicode-trie@2.0.0:
+    dependencies:
+      pako: 0.2.9
+      tiny-inflate: 1.0.3
+
+  unpipe@1.0.0: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
+  util-deprecate@1.0.2: {}
+
+  wcwidth@1.0.1:
+    dependencies:
+      defaults: 1.0.4
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  which@4.0.0:
+    dependencies:
+      isexe: 3.1.5
+
+  word-wrap@1.2.5: {}
+
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  yocto-queue@0.1.0: {}
+
+  yoga-layout@3.2.1: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+onlyBuiltDependencies:
+  - '@prisma/client'
+  - '@prisma/engines'
+  - prisma

--- a/src/commands/player/profile.ts
+++ b/src/commands/player/profile.ts
@@ -5,154 +5,202 @@ import {
   SubCommand,
   LocalesT,
   Declare,
-  Options,
-} from "seyfert";
+  Options
+} from 'seyfert';
 
 import {
   generateProfileV1,
-  generateProfileV2,
-} from "../../utils/images/profile";
-import { trackerModesMap } from "../../lib/api/trackergg/tracker-api";
-import { autocompleteUserCallback } from "../../utils/callbacks";
+  generateProfileV2
+} from '../../utils/images/profile';
+import { trackerModesMap } from '../../lib/api/trackergg/tracker-api';
+import { autocompleteUserCallback } from '../../utils/callbacks';
+import { callbackPaginator } from '../../utils/paginator';
+
+const AllSeasons = [
+  {
+    name: 'All Seasons',
+    value: 'all'
+  } as const,
+  {
+    name: 'Season 6.5',
+    value: '14'
+  } as const,
+  {
+    name: 'Season 6',
+    value: '13'
+  } as const,
+  {
+    name: 'Season 5.5',
+    value: '12'
+  } as const,
+  {
+    name: 'Season 5',
+    value: '11'
+  } as const,
+  {
+    name: 'Season 4.5',
+    value: '10'
+  } as const,
+  {
+    name: 'Season 4',
+    value: '9'
+  } as const,
+  {
+    name: 'Season 3.5',
+    value: '8'
+  } as const,
+  {
+    name: 'Season 3',
+    value: '7'
+  } as const,
+  {
+    name: 'Season 2.5',
+    value: '6'
+  } as const,
+  {
+    name: 'Season 2',
+    value: '5'
+  } as const,
+  {
+    name: 'Season 1.5',
+    value: '4'
+  } as const,
+  {
+    name: 'Season 1',
+    value: '3'
+  } as const,
+  {
+    name: 'Season 0.5',
+    value: '2'
+  } as const,
+  {
+    name: 'Season 0',
+    value: '1'
+  } as const
+];
 
 const options = {
-  "name-or-id": createStringOption({
-    description: "Enter the player name or ID to identify the player.",
+  'name-or-id': createStringOption({
+    description: 'Enter the player name or ID to identify the player.',
     locales: {
-      name: "commands.commonOptions.nameOrId.name",
-      description: "commands.commonOptions.nameOrId.description",
+      name: 'commands.commonOptions.nameOrId.name',
+      description: 'commands.commonOptions.nameOrId.description'
     },
-    autocomplete: autocompleteUserCallback,
+    autocomplete: autocompleteUserCallback
   }),
-  "game-mode": createStringOption({
-    description: "Choose the game mode to display stats for.",
+  'game-mode': createStringOption({
+    description: 'Choose the game mode to display stats for.',
     required: false,
     choices: [
       {
-        name: "Ranked",
-        value: "ranked",
+        name: 'Ranked',
+        value: 'ranked'
       },
       {
-        name: "Casual",
-        value: "casual",
+        name: 'Casual',
+        value: 'casual'
       },
       {
-        name: "Both",
-        value: "both",
-      },
+        name: 'Both',
+        value: 'both'
+      }
     ] as const,
     locales: {
-      name: "commands.commonOptions.gameMode.name",
-      description: "commands.commonOptions.gameMode.description",
-    },
+      name: 'commands.commonOptions.gameMode.name',
+      description: 'commands.commonOptions.gameMode.description'
+    }
   }),
   season: createStringOption({
-    description: "Choose the season to display stats for.",
+    description: 'Choose the season to display stats for.',
     required: false,
-    choices: [
-      { name: "All Seasons", value: "all" },
-      { name: "Season 6", value: "13" },
-      { name: "Season 5.5", value: "12" },
-      { name: "Season 5", value: "11" },
-      { name: "Season 4.5", value: "10" },
-      { name: "Season 4", value: "9" },
-      { name: "Season 3.5", value: "8" },
-      { name: "Season 3", value: "7" },
-      { name: "Season 2.5", value: "6" },
-      { name: "Season 2", value: "5" },
-      { name: "Season 1.5", value: "4" },
-      { name: "Season 1", value: "3" },
-      { name: "Season 0.5", value: "2" },
-      { name: "Season 0", value: "1" },
-    ] as const,
+    choices: AllSeasons
   }),
-  "image-version": createStringOption({
-    description: "Choose the image version to display stats for.",
+  'image-version': createStringOption({
+    description: 'Choose the image version to display stats for.',
     choices: [
       {
-        name: "V1",
-        value: "v1",
+        name: 'V1',
+        value: 'v1'
       },
       {
-        name: "V2",
-        value: "v2",
-      },
+        name: 'V2',
+        value: 'v2'
+      }
     ] as const,
     locales: {
-      name: "commands.player.profile.options.imageVersion.name",
-      description: "commands.player.profile.options.imageVersion.description",
-    },
-  }),
+      name: 'commands.player.profile.options.imageVersion.name',
+      description: 'commands.player.profile.options.imageVersion.description'
+    }
+  })
 };
 
 @Declare({
-  name: "profile",
+  name: 'profile',
   description:
-    "Get detailed stats like roles, rank, and top heroes for a player.",
+    'Get detailed stats like roles, rank, and top heroes for a player.'
 })
-@LocalesT("commands.player.profile.name", "commands.player.profile.description")
+@LocalesT('commands.player.profile.name', 'commands.player.profile.description')
 @Options(options)
 export default class ProfileCommand extends SubCommand {
   async run(ctx: CommandContext<typeof options>) {
     await ctx.deferReply();
 
     const nameOrId =
-      ctx.options["name-or-id"] ||
+      ctx.options['name-or-id'] ||
       (
         await ctx.client.prisma.user.findFirst({
           where: {
-            userID: ctx.author.id,
-          },
+            userID: ctx.author.id
+          }
         })
       )?.rivalsUUID;
     if (!nameOrId) {
       return ctx.editOrReply({
-        content: ctx.t.commands.commonErrors.noNameOrId.get(),
+        content: ctx.t.commands.commonErrors.noNameOrId.get()
       });
     }
 
-    // todo: la season actual no deberia estar hardcodeada....
-    const season = ctx.options.season ?? "13";
-    const parsedSeason = season === "all" ? "all" : parseInt(season);
 
-    if (season !== "all") {
-      const seasonNumber = parseInt(season);
-      if (isNaN(seasonNumber) || seasonNumber < 1 || seasonNumber > 13) {
-        return ctx.editOrReply({
-          content: ctx.t.commands.commonErrors.invalidSeason.get(),
-        });
-      }
-    }
+    const mode = ctx.options['game-mode'] ?? 'competitive';
 
-    const mode = ctx.options["game-mode"] ?? "competitive";
+    await callbackPaginator(ctx, AllSeasons, {
+      async callback(data) {
+        const page = data[0];
+        const parsedSeason = page.value === 'all'
+          ? 'all'
+          : parseInt(page.value);
+        const [player, heroes] = await Promise.all([
+          ctx.client.api.getPlayerCareerData(
+            nameOrId,
+            trackerModesMap[mode],
+            parsedSeason
+          ),
+          ctx.client.api.getTrackerHeroesMetadata()
+        ]);
 
-    const [player, heroes] = await Promise.all([
-      ctx.client.api.getPlayerCareerData(
-        nameOrId,
-        trackerModesMap[mode as keyof typeof trackerModesMap],
-        parsedSeason,
-      ),
-      ctx.client.api.getTrackerHeroesMetadata(),
-    ]);
+        if (!player || !heroes) {
+          return {
+            content: ctx.t.commands.commonErrors.playerNotFound.get()
+          };
+        }
 
-    if (!player || !heroes) {
-      return ctx.editOrReply({
-        content: ctx.t.commands.commonErrors.playerNotFound.get(),
-      });
-    }
+        const buffer = await (
+          ctx.options['image-version'] === 'v1'
+            ? generateProfileV1
+            : generateProfileV2
+        )(player, heroes, ctx.options['game-mode']);
 
-    const buffer = await (
-      ctx.options["image-version"] === "v1"
-        ? generateProfileV1
-        : generateProfileV2
-    )(player, heroes, ctx.options["game-mode"]);
-
-    return ctx.editOrReply({
-      files: [
-        new AttachmentBuilder()
-          .setName("profile.png")
-          .setFile("buffer", buffer),
-      ],
+        return {
+          content: page.name,
+          files: [
+            new AttachmentBuilder()
+              .setName('profile.png')
+              .setFile('buffer', buffer)
+          ]
+        };
+      },
+      pageSize: 1
     });
+
   }
 }

--- a/src/commands/player/profile.ts
+++ b/src/commands/player/profile.ts
@@ -23,54 +23,50 @@ const AllSeasons = [
   } as const,
   {
     name: 'Season 6.5',
-    value: '14'
-  } as const,
-  {
-    name: 'Season 6',
     value: '13'
   } as const,
   {
-    name: 'Season 5.5',
+    name: 'Season 6',
     value: '12'
   } as const,
   {
-    name: 'Season 5',
+    name: 'Season 5.5',
     value: '11'
   } as const,
   {
-    name: 'Season 4.5',
+    name: 'Season 5',
     value: '10'
   } as const,
   {
-    name: 'Season 4',
+    name: 'Season 4.5',
     value: '9'
   } as const,
   {
-    name: 'Season 3.5',
+    name: 'Season 4',
     value: '8'
   } as const,
   {
-    name: 'Season 3',
+    name: 'Season 3.5',
     value: '7'
   } as const,
   {
-    name: 'Season 2.5',
+    name: 'Season 3',
     value: '6'
   } as const,
   {
-    name: 'Season 2',
+    name: 'Season 2.5',
     value: '5'
   } as const,
   {
-    name: 'Season 1.5',
+    name: 'Season 2',
     value: '4'
   } as const,
   {
-    name: 'Season 1',
+    name: 'Season 1.5',
     value: '3'
   } as const,
   {
-    name: 'Season 0.5',
+    name: 'Season 1',
     value: '2'
   } as const,
   {

--- a/src/commands/player/profile.ts
+++ b/src/commands/player/profile.ts
@@ -1,94 +1,158 @@
-import { type CommandContext, createStringOption, AttachmentBuilder, SubCommand, LocalesT, Declare, Options } from 'seyfert';
+import {
+  type CommandContext,
+  createStringOption,
+  AttachmentBuilder,
+  SubCommand,
+  LocalesT,
+  Declare,
+  Options,
+} from "seyfert";
 
-import { generateProfileV1, generateProfileV2 } from '../../utils/images/profile';
-import { autocompleteUserCallback } from '../../utils/callbacks';
+import {
+  generateProfileV1,
+  generateProfileV2,
+} from "../../utils/images/profile";
+import { trackerModesMap } from "../../lib/api/trackergg/tracker-api";
+import { autocompleteUserCallback } from "../../utils/callbacks";
 
 const options = {
-  'name-or-id': createStringOption({
-    description: 'Enter the player name or ID to identify the player.',
+  "name-or-id": createStringOption({
+    description: "Enter the player name or ID to identify the player.",
     locales: {
-      name: 'commands.commonOptions.nameOrId.name',
-      description: 'commands.commonOptions.nameOrId.description'
+      name: "commands.commonOptions.nameOrId.name",
+      description: "commands.commonOptions.nameOrId.description",
     },
-    autocomplete: autocompleteUserCallback
+    autocomplete: autocompleteUserCallback,
   }),
-  'game-mode': createStringOption({
-    description: 'Choose the game mode to display stats for.',
+  "game-mode": createStringOption({
+    description: "Choose the game mode to display stats for.",
     required: false,
     choices: [
       {
-        name: 'Ranked',
-        value: 'ranked'
+        name: "Ranked",
+        value: "ranked",
       },
       {
-        name: 'Casual',
-        value: 'casual'
+        name: "Casual",
+        value: "casual",
       },
       {
-        name: 'Both',
-        value: 'both'
-      }
+        name: "Both",
+        value: "both",
+      },
     ] as const,
     locales: {
-      name: 'commands.commonOptions.gameMode.name',
-      description: 'commands.commonOptions.gameMode.description'
-    }
+      name: "commands.commonOptions.gameMode.name",
+      description: "commands.commonOptions.gameMode.description",
+    },
   }),
-  'image-version': createStringOption({
-    description: 'Choose the image version to display stats for.',
+  season: createStringOption({
+    description: "Choose the season to display stats for.",
+    required: false,
+    choices: [
+      { name: "All Seasons", value: "all" },
+      { name: "Season 6", value: "13" },
+      { name: "Season 5.5", value: "12" },
+      { name: "Season 5", value: "11" },
+      { name: "Season 4.5", value: "10" },
+      { name: "Season 4", value: "9" },
+      { name: "Season 3.5", value: "8" },
+      { name: "Season 3", value: "7" },
+      { name: "Season 2.5", value: "6" },
+      { name: "Season 2", value: "5" },
+      { name: "Season 1.5", value: "4" },
+      { name: "Season 1", value: "3" },
+      { name: "Season 0.5", value: "2" },
+      { name: "Season 0", value: "1" },
+    ] as const,
+  }),
+  "image-version": createStringOption({
+    description: "Choose the image version to display stats for.",
     choices: [
       {
-        name: 'V1',
-        value: 'v1'
+        name: "V1",
+        value: "v1",
       },
       {
-        name: 'V2',
-        value: 'v2'
-      }
+        name: "V2",
+        value: "v2",
+      },
     ] as const,
     locales: {
-      name: 'commands.player.profile.options.imageVersion.name',
-      description: 'commands.player.profile.options.imageVersion.description'
-    }
-  })
+      name: "commands.player.profile.options.imageVersion.name",
+      description: "commands.player.profile.options.imageVersion.description",
+    },
+  }),
 };
 
 @Declare({
-  name: 'profile',
-  description: 'Get detailed stats like roles, rank, and top heroes for a player.'
+  name: "profile",
+  description:
+    "Get detailed stats like roles, rank, and top heroes for a player.",
 })
-@LocalesT('commands.player.profile.name', 'commands.player.profile.description')
+@LocalesT("commands.player.profile.name", "commands.player.profile.description")
 @Options(options)
 export default class ProfileCommand extends SubCommand {
   async run(ctx: CommandContext<typeof options>) {
     await ctx.deferReply();
 
-    const nameOrId = ctx.options['name-or-id'] || (await ctx.client.prisma.user.findFirst({
-      where: {
-        userID: ctx.author.id
-      }
-    }))?.rivalsUUID;
+    const nameOrId =
+      ctx.options["name-or-id"] ||
+      (
+        await ctx.client.prisma.user.findFirst({
+          where: {
+            userID: ctx.author.id,
+          },
+        })
+      )?.rivalsUUID;
     if (!nameOrId) {
       return ctx.editOrReply({
-        content: ctx.t.commands.commonErrors.noNameOrId.get()
+        content: ctx.t.commands.commonErrors.noNameOrId.get(),
       });
     }
 
-    const player = await ctx.client.api.getPlayer(nameOrId);
+    // todo: la season actual no deberia estar hardcodeada....
+    const season = ctx.options.season ?? "13";
+    const parsedSeason = season === "all" ? "all" : parseInt(season);
 
-    if (!player) {
+    if (season !== "all") {
+      const seasonNumber = parseInt(season);
+      if (isNaN(seasonNumber) || seasonNumber < 1 || seasonNumber > 13) {
+        return ctx.editOrReply({
+          content: ctx.t.commands.commonErrors.invalidSeason.get(),
+        });
+      }
+    }
+
+    const mode = ctx.options["game-mode"] ?? "competitive";
+
+    const [player, heroes] = await Promise.all([
+      ctx.client.api.getPlayerCareerData(
+        nameOrId,
+        trackerModesMap[mode as keyof typeof trackerModesMap],
+        parsedSeason,
+      ),
+      ctx.client.api.getTrackerHeroesMetadata(),
+    ]);
+
+    if (!player || !heroes) {
       return ctx.editOrReply({
-        content: ctx.t.commands.commonErrors.playerNotFound.get()
+        content: ctx.t.commands.commonErrors.playerNotFound.get(),
       });
     }
 
-    const buffer = await (ctx.options['image-version'] === 'v1'
-      ? generateProfileV1
-      : generateProfileV2)(player, await ctx.client.api.getHeroes(), ctx.options['game-mode']);
-    await ctx.editOrReply({
+    const buffer = await (
+      ctx.options["image-version"] === "v1"
+        ? generateProfileV1
+        : generateProfileV2
+    )(player, heroes, ctx.options["game-mode"]);
+
+    return ctx.editOrReply({
       files: [
-        new AttachmentBuilder().setName('profile.png').setFile('buffer', buffer)
-      ]
+        new AttachmentBuilder()
+          .setName("profile.png")
+          .setFile("buffer", buffer),
+      ],
     });
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,16 @@
-import { type ParseMiddlewares, type ParseLocales, type ParseClient, type UsingClient, Formatter, Client } from 'seyfert';
-import { PresenceUpdateStatus, ActivityType, MessageFlags } from 'seyfert/lib/types';
+import {
+  type ParseMiddlewares,
+  type ParseLocales,
+  type ParseClient,
+  type UsingClient,
+  Formatter,
+  Client
+} from 'seyfert';
+import {
+  PresenceUpdateStatus,
+  ActivityType,
+  MessageFlags
+} from 'seyfert/lib/types';
 import { basename, join, sep } from 'node:path';
 import { Api as TopGGAPI } from '@top-gg/sdk';
 import { GlobalFonts } from '@napi-rs/canvas';
@@ -13,138 +24,179 @@ import { PrismaClient } from '../prisma/client';
 import { middlewares } from './middlewares';
 import { Api } from './lib/managers/api';
 // Register fonts
-GlobalFonts.registerFromPath(join(process.cwd(), 'assets', 'fonts', 'Inter', 'Inter_28pt-Regular.ttf'), 'InterRegular');
-GlobalFonts.registerFromPath(join(process.cwd(), 'assets', 'fonts', 'Inter', 'Inter_28pt-Black.ttf'), 'InterBlack');
-GlobalFonts.registerFromPath(join(process.cwd(), 'assets', 'fonts', 'Inter', 'Inter_28pt-SemiBold.ttf'), 'InterSemiBold');
-GlobalFonts.registerFromPath(join(process.cwd(), 'assets', 'fonts', 'Inter', 'Inter_28pt-Bold.ttf'), 'InterBold');
-GlobalFonts.registerFromPath(join(process.cwd(), 'assets', 'fonts', 'RefrigeratorDeluxeBold.otf'), 'RefrigeratorDeluxeBold');
-GlobalFonts.registerFromPath(join(process.cwd(), 'assets', 'fonts', 'leaderboard.ttf'), 'leaderboard');
+GlobalFonts.registerFromPath(
+  join(process.cwd(), 'assets', 'fonts', 'Inter', 'Inter_28pt-Regular.ttf'),
+  'InterRegular'
+);
+GlobalFonts.registerFromPath(
+  join(process.cwd(), 'assets', 'fonts', 'Inter', 'Inter_28pt-Black.ttf'),
+  'InterBlack'
+);
+GlobalFonts.registerFromPath(
+  join(process.cwd(), 'assets', 'fonts', 'Inter', 'Inter_28pt-SemiBold.ttf'),
+  'InterSemiBold'
+);
+GlobalFonts.registerFromPath(
+  join(process.cwd(), 'assets', 'fonts', 'Inter', 'Inter_28pt-Bold.ttf'),
+  'InterBold'
+);
+GlobalFonts.registerFromPath(
+  join(process.cwd(), 'assets', 'fonts', 'RefrigeratorDeluxeBold.otf'),
+  'RefrigeratorDeluxeBold'
+);
+GlobalFonts.registerFromPath(
+  join(process.cwd(), 'assets', 'fonts', 'leaderboard.ttf'),
+  'leaderboard'
+);
 
 const client = new Client({
-    commands: {
-        defaults: {
-            async onRunError(ctx, error) {
-                let files: AttachmentBuilder[] | undefined;
-                if (ctx.isChat() && ctx.interaction.data.options?.length) {
-                    files = [
-                        new AttachmentBuilder()
-                            .setFile('buffer', Buffer.from(JSON.stringify(ctx.interaction.data.options, null, 2)))
-                            .setName('options.txt')
-                    ];
-                }
-
-                client.logger.error(
-                    ctx.author.id,
-                    ctx.author.username,
-                    ctx.fullCommandName,
-                    error
-                );
-
-                const content = [
-                    'Report this error on the [support server](<https://discord.gg/AcruVkyYHm>).',
-                    Formatter.codeBlock((error instanceof Error
-                        ? error.message
-                        : typeof error === 'object' && error && 'message' in error && typeof error.message === 'string'
-                            ? error.message
-                            : typeof error === 'string'
-                                ? error
-                                : 'Unknown error').slice(0, 1_500), 'ts')
-                ];
-
-                if (content[1].includes('This player\'s profile is private.')) {
-                    return ctx.editOrReply({
-                        content: ctx.t.commands.commonErrors.privateProfile.get(),
-                        files: [
-                            {
-                                data: await Bun.file(
-                                    join(process.cwd(), 'assets', 'private-profile.png')
-                                ).bytes(),
-                                filename: 'private-profile.png'
-                            }
-                        ]
-                    });
-                }
-
-                void ctx.client.webhooks.writeMessage(WEBHOOK_ID, WEBHOOK_TOKEN, {
-                    body: {
-                        content: content.slice(1).join('\n'),
-                        embeds: [{
-                            description: [
-                                ctx.author.id,
-                                ctx.author.username,
-                                ctx.fullCommandName
-                            ].join(' | ')
-                        }],
-                        files
-                    }
-                }).catch((err: unknown) => {
-                    ctx.client.logger.error('webhook', err);
-                });
-
-                return ctx.editOrReply({
-                    content: content.join('\n')
-                });
-            },
-            onMiddlewaresError(ctx, error) {
-                return ctx.editOrReply({
-                    content: error,
-                    flags: MessageFlags.Ephemeral
-                });
-            },
-            onOptionsError(ctx, metadata) {
-                client.logger.error(
-                    ctx.author.id,
-                    ctx.author.username,
-                    ctx.fullCommandName,
-                    metadata
-                );
-                return ctx.editOrReply({
-                    content: Object.entries(metadata).filter(([, value]) => value.failed).map(([key, value]) => `${key}: ${value.value as string}`).join('\n'),
-                    flags: MessageFlags.Ephemeral
-                });
-            },
-            async onAfterRun(ctx) {
-                if (Math.random() < 0.15) {
-                    const hasVoted = await ctx.client.topgg.hasVoted(ctx.author.id).catch(() => false);
-                    if (!hasVoted) {
-                        await ctx.followup({
-                            content: ctx.t.commands.others.noVoted.get(),
-                            flags: MessageFlags.Ephemeral
-                        });
-                    }
-                }
-            }
+  commands: {
+    defaults: {
+      async onRunError(ctx, error) {
+        let files: AttachmentBuilder[] | undefined;
+        if (ctx.isChat() && ctx.interaction.data.options?.length) {
+          files = [
+            new AttachmentBuilder()
+              .setFile(
+                'buffer',
+                Buffer.from(
+                  JSON.stringify(ctx.interaction.data.options, null, 2)
+                )
+              )
+              .setName('options.txt')
+          ];
         }
-    },
-    presence() {
-        return {
-            activities: [{
-                name: 'Gonna get sticky!',
-                type: ActivityType.Custom,
-                state: 'Gonna get sticky!'
-            }],
-            afk: false,
-            since: Date.now(),
-            status: PresenceUpdateStatus.Online
-        };
-    },
-    globalMiddlewares: ['cooldown']
+
+        client.logger.error(
+          ctx.author.id,
+          ctx.author.username,
+          ctx.fullCommandName,
+          error
+        );
+
+        const content = [
+          'Report this error on the [support server](<https://discord.gg/AcruVkyYHm>).',
+          Formatter.codeBlock(
+            (error instanceof Error
+              ? error.message
+              : typeof error === 'object' &&
+                  error &&
+                  'message' in error &&
+                  typeof error.message === 'string'
+                ? error.message
+                : typeof error === 'string'
+                  ? error
+                  : 'Unknown error'
+            ).slice(0, 1_500),
+            'ts'
+          )
+        ];
+
+        if (content[1].includes('This player\'s profile is private.')) {
+          return ctx.editOrReply({
+            content: ctx.t.commands.commonErrors.privateProfile.get(),
+            files: [
+              {
+                data: await Bun.file(
+                  join(process.cwd(), 'assets', 'private-profile.png')
+                ).bytes(),
+                filename: 'private-profile.png'
+              }
+            ]
+          });
+        }
+
+        void ctx.client.webhooks
+          .writeMessage(WEBHOOK_ID, WEBHOOK_TOKEN, {
+            body: {
+              content: content.slice(1).join('\n'),
+              embeds: [
+                {
+                  description: [
+                    ctx.author.id,
+                    ctx.author.username,
+                    ctx.fullCommandName
+                  ].join(' | ')
+                }
+              ],
+              files
+            }
+          })
+          .catch((err: unknown) => {
+            ctx.client.logger.error('webhook', err);
+          });
+
+        return ctx.editOrReply({
+          content: content.join('\n')
+        });
+      },
+      onMiddlewaresError(ctx, error) {
+        return ctx.editOrReply({
+          content: error,
+          flags: MessageFlags.Ephemeral
+        });
+      },
+      onOptionsError(ctx, metadata) {
+        client.logger.error(
+          ctx.author.id,
+          ctx.author.username,
+          ctx.fullCommandName,
+          metadata
+        );
+        return ctx.editOrReply({
+          content: Object.entries(metadata)
+            .filter(([, value]) => value.failed)
+            .map(([key, value]) => `${key}: ${value.value as string}`)
+            .join('\n'),
+          flags: MessageFlags.Ephemeral
+        });
+      },
+      async onAfterRun(ctx) {
+        if (Math.random() < 0.15) {
+          const hasVoted = await ctx.client.topgg
+            .hasVoted(ctx.author.id)
+            .catch(() => false);
+          if (!hasVoted) {
+            await ctx.followup({
+              content: ctx.t.commands.others.noVoted.get(),
+              flags: MessageFlags.Ephemeral
+            });
+          }
+        }
+      }
+    }
+  },
+  presence() {
+    return {
+      activities: [
+        {
+          name: 'Gonna get sticky!',
+          type: ActivityType.Custom,
+          state: 'Gonna get sticky!'
+        }
+      ],
+      afk: false,
+      since: Date.now(),
+      status: PresenceUpdateStatus.Online
+    };
+  },
+  globalMiddlewares: ['cooldown']
 }) as UsingClient & Client;
 
 client.setServices({
-    langs: {
-        aliases: {
-            'es-419': ['es-ES'],
-            'en-US': ['en-GB']
-        },
-        default: 'en-US'
+  langs: {
+    aliases: {
+      'es-419': ['es-ES'],
+      'en-US': ['en-GB']
     },
-    middlewares,
-    cache: {
-        disabledCache: {
-            messages: true
-        }
+    default: 'en-US'
+  },
+  middlewares,
+  cache: {
+    disabledCache: {
+      messages: true
     }
+  }
 });
 
 client.langs.filter = (path) => basename(path) === '_.ts';
@@ -153,14 +205,15 @@ client.langs.onFile = (locale, { path, file }) => file.default
     ? {
         file: file.default,
         locale: path.split(sep).at(-2) ?? locale
-    }
+      }
     : false;
 
-
 client.redis = createClient();
-await client.redis.on('error', (err) => {
+await client.redis
+  .on('error', (err) => {
     client.logger.error('Redis Client Error', err);
-}).connect();
+  })
+  .connect();
 
 client.prisma = new PrismaClient();
 
@@ -170,30 +223,33 @@ client.api = new Api(API_KEY, client.redis);
 
 client.topgg = new TopGGAPI(TOPGG_TOKEN);
 
-await client.api.getHeroes();
-
-await client.api.getAllMaps();
+// await client.api.getHeroes();
+//
+// await client.api.getAllMaps();
 
 await client.start();
 
 await client.uploadCommands({
-    cachePath: join(process.cwd(), 'cache', 'seyfert_commands.json')
+  cachePath: join(process.cwd(), 'cache', 'seyfert_commands.json')
 });
 
 declare module 'seyfert' {
-    interface RegisteredMiddlewares
-        extends ParseMiddlewares<typeof middlewares> { }
+  interface RegisteredMiddlewares extends ParseMiddlewares<
+    typeof middlewares
+  > {}
 
-    interface UsingClient extends ParseClient<Client<true>> {
-        api: Api;
-        redis: ReturnType<typeof createClient>;
-        topgg: TopGGAPI;
-        prisma: PrismaClient;
-    }
+  interface UsingClient extends ParseClient<Client<true>> {
+    api: Api;
+    redis: ReturnType<typeof createClient>;
+    topgg: TopGGAPI;
+    prisma: PrismaClient;
+  }
 
-    interface DefaultLocale extends ParseLocales<typeof import('./locales/en-US/_')['default']> { }
+  interface DefaultLocale extends ParseLocales<
+    (typeof import('./locales/en-US/_'))['default']
+  > {}
 
-    interface ExtraProps {
-        ratelimit?: Ratelimit;
-    }
+  interface ExtraProps {
+    ratelimit?: Ratelimit;
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,9 +80,9 @@ const client = new Client({
             (error instanceof Error
               ? error.message
               : typeof error === 'object' &&
-                  error &&
-                  'message' in error &&
-                  typeof error.message === 'string'
+                error &&
+                'message' in error &&
+                typeof error.message === 'string'
                 ? error.message
                 : typeof error === 'string'
                   ? error
@@ -202,11 +202,11 @@ client.setServices({
 client.langs.filter = (path) => basename(path) === '_.ts';
 
 client.langs.onFile = (locale, { path, file }) => file.default
-    ? {
-        file: file.default,
-        locale: path.split(sep).at(-2) ?? locale
-      }
-    : false;
+  ? {
+    file: file.default,
+    locale: path.split(sep).at(-2) ?? locale
+  }
+  : false;
 
 client.redis = createClient();
 await client.redis
@@ -236,7 +236,7 @@ await client.uploadCommands({
 declare module 'seyfert' {
   interface RegisteredMiddlewares extends ParseMiddlewares<
     typeof middlewares
-  > {}
+  > { }
 
   interface UsingClient extends ParseClient<Client<true>> {
     api: Api;
@@ -247,7 +247,7 @@ declare module 'seyfert' {
 
   interface DefaultLocale extends ParseLocales<
     (typeof import('./locales/en-US/_'))['default']
-  > {}
+  > { }
 
   interface ExtraProps {
     ratelimit?: Ratelimit;

--- a/src/lib/api/trackergg/dto/CareerDTO.ts
+++ b/src/lib/api/trackergg/dto/CareerDTO.ts
@@ -146,7 +146,7 @@ export enum AssistsDisplayType {
   TimeSeconds = 'TimeSeconds'
 }
 
-export interface AssistsMetadata {}
+export interface AssistsMetadata { }
 
 export interface LifetimePeakRanked {
   displayName: DisplayName;

--- a/src/lib/api/trackergg/dto/CareerDTO.ts
+++ b/src/lib/api/trackergg/dto/CareerDTO.ts
@@ -1,0 +1,215 @@
+export interface CareerDTO {
+  data: Datum[];
+}
+
+export interface Datum {
+  type: Type;
+  attributes: Attributes;
+  metadata: DatumMetadata;
+  expiryDate: string;
+  stats: Stats;
+}
+
+export interface Attributes {
+  season?: number | null;
+  mode?: Mode;
+  heroId?: number;
+  role?: Role;
+  roleId?: Role;
+}
+
+export enum Mode {
+  All = 'all',
+  Competitive = 'competitive',
+  QuickMatch = 'quick-match'
+}
+
+export enum Role {
+  Duelist = 'duelist',
+  Strategist = 'strategist',
+  Vanguard = 'vanguard'
+}
+
+export interface DatumMetadata {
+  name?: string;
+  imageUrl?: string;
+  roleName?: RoleName;
+  color?: string;
+}
+
+export enum RoleName {
+  Duelist = 'Duelist',
+  Strategist = 'Strategist',
+  Vanguard = 'Vanguard'
+}
+
+export interface Stats {
+  timePlayed?: Assists;
+  matchesPlayed?: Assists;
+  matchesWon?: Assists;
+  matchesWinPct?: Assists;
+  kills?: Assists;
+  deaths?: Assists;
+  assists?: Assists;
+  kdRatio?: Assists;
+  kdaRatio?: Assists;
+  totalHeroDamage?: Assists;
+  totalHeroDamagePerMinute?: Assists;
+  totalHeroHeal?: Assists;
+  totalHeroHealPerMinute?: Assists;
+  totalDamageTaken?: Assists;
+  totalDamageTakenPerMinute?: Assists;
+  lastKills?: Assists;
+  headKills?: Assists;
+  soloKills?: Assists;
+  maxSurvivalKills?: Assists;
+  maxContinueKills?: Assists;
+  continueKills3?: Assists;
+  continueKills4?: Assists;
+  continueKills5?: Assists;
+  continueKills6?: Assists;
+  mainAttacks?: Assists;
+  mainAttackHits?: Assists;
+  shieldHits?: Assists;
+  summonerHits?: Assists;
+  chaosHits?: Assists;
+  totalMvp?: Assists;
+  totalMvpPct?: Assists;
+  totalSvp?: Assists;
+  totalSvpPct?: Assists;
+  ranked?: Ranked;
+  peakRanked?: Ranked;
+  peakTiers?: PeakTiers;
+  lifetimePeakRanked?: LifetimePeakRanked;
+  timePlayedWon?: Assists;
+  survivalKills?: Assists;
+  continueKills?: Assists;
+  featureNormalData1?: Assists;
+  featureNormalData2?: Assists;
+  featureNormalData3?: Assists;
+  featureCriticalRate1CritHits?: Assists;
+  featureCriticalRate1Hits?: Assists;
+  featureCriticalRate2CritHits?: Assists;
+  featureCriticalRate2Hits?: Assists;
+  featureHitRate1UseCount?: Assists;
+  featureHitRate1RealHitHeroCount?: Assists;
+  featureHitRate1ChaosHits?: Assists;
+  featureHitRate1AllyHits?: Assists;
+  featureHitRate1HeroHits?: Assists;
+  featureHitRate1EnemyHits?: Assists;
+  featureHitRate1ShieldHits?: Assists;
+  featureHitRate1SummonerHits?: Assists;
+  featureHitRate2UseCount?: Assists;
+  featureHitRate2RealHitHeroCount?: Assists;
+  featureHitRate2ChaosHits?: Assists;
+  featureHitRate2AllyHits?: Assists;
+  featureHitRate2HeroHits?: Assists;
+  featureHitRate2EnemyHits?: Assists;
+  featureHitRate2ShieldHits?: Assists;
+  featureHitRate2SummonerHits?: Assists;
+  featureSpecialData1Total?: Assists;
+  featureSpecialData1Value?: Assists;
+}
+
+export interface Assists {
+  displayName: string;
+  displayCategory: DisplayCategory;
+  category: Category;
+  metadata: AssistsMetadata;
+  value: number | null;
+  displayValue?: string;
+  displayType: AssistsDisplayType;
+  percentile?: number;
+}
+
+export enum Category {
+  Combat = 'combat',
+  Damage = 'damage',
+  Feature = 'feature',
+  Game = 'game',
+  Healing = 'healing'
+}
+
+export enum DisplayCategory {
+  Combat = 'Combat',
+  Damage = 'Damage',
+  Feature = 'Feature',
+  Game = 'Game',
+  Healing = 'Healing'
+}
+
+export enum AssistsDisplayType {
+  Number = 'Number',
+  NumberPercentage = 'NumberPercentage',
+  NumberPrecision1 = 'NumberPrecision1',
+  NumberPrecision2 = 'NumberPrecision2',
+  TimeSeconds = 'TimeSeconds'
+}
+
+export interface AssistsMetadata {}
+
+export interface LifetimePeakRanked {
+  displayName: DisplayName;
+  category?: string;
+  metadata: LifetimePeakRankedMetadata;
+  value: number;
+  displayValue: string | null;
+  displayType: LifetimePeakRankedDisplayType;
+}
+
+export enum DisplayName {
+  LifetimePeakRankScore = 'Lifetime Peak Rank Score',
+  PeakRating = 'Peak Rating'
+}
+
+export enum LifetimePeakRankedDisplayType {
+  Custom = 'Custom',
+  String = 'String'
+}
+
+export interface LifetimePeakRankedMetadata {
+  unit: Unit;
+  iconUrl: string;
+  tierName: string;
+  tierShortName: string;
+  color: string;
+  season: number;
+  seasonName: string;
+  seasonShortName: string;
+}
+
+export enum Unit {
+  Rs = 'RS'
+}
+
+export interface Ranked {
+  displayName: string;
+  category: string;
+  metadata: PeakRankedMetadata;
+  value: number;
+  displayValue: string;
+  displayType: LifetimePeakRankedDisplayType;
+}
+
+export interface PeakRankedMetadata {
+  unit: Unit;
+  iconUrl: string;
+  tierName: string;
+  tierShortName: string;
+  color: string;
+}
+
+export interface PeakTiers {
+  displayName: string;
+  metadata: AssistsMetadata;
+  value: LifetimePeakRanked[];
+  displayValue: null;
+  displayType: LifetimePeakRankedDisplayType;
+}
+
+export enum Type {
+  Hero = 'hero',
+  HeroRole = 'hero-role',
+  Overview = 'overview',
+  RankedPeaks = 'ranked-peaks'
+}

--- a/src/lib/api/trackergg/dto/CareerDTO.ts
+++ b/src/lib/api/trackergg/dto/CareerDTO.ts
@@ -117,7 +117,7 @@ export interface Assists {
   category: Category;
   metadata: AssistsMetadata;
   value: number | null;
-  displayValue?: string;
+  displayValue?: string | null;
   displayType: AssistsDisplayType;
   percentile?: number;
 }

--- a/src/lib/api/trackergg/dto/HeroDTO.ts
+++ b/src/lib/api/trackergg/dto/HeroDTO.ts
@@ -1,0 +1,40 @@
+export interface Welcome {
+  data: Data;
+}
+
+export interface Data {
+  items: Item[];
+}
+
+export interface Item {
+  type: Type;
+  key: string;
+  locale: Locale;
+  name: string;
+  description: string;
+  imageUrl: string;
+  roleKey: RoleKey;
+  roleName: RoleName;
+}
+
+export enum Locale {
+  EnUS = 'en-US'
+}
+
+export enum RoleKey {
+  Duelist = 'duelist',
+  Strategist = 'strategist',
+  Unknown = 'unknown',
+  Vanguard = 'vanguard'
+}
+
+export enum RoleName {
+  Duelist = 'Duelist',
+  Strategist = 'Strategist',
+  Unknown = 'Unknown',
+  Vanguard = 'Vanguard'
+}
+
+export enum Type {
+  Hero = 'hero'
+}

--- a/src/lib/api/trackergg/dto/ProfileDTO.ts
+++ b/src/lib/api/trackergg/dto/ProfileDTO.ts
@@ -1,0 +1,280 @@
+export interface Profile {
+  data: Data;
+}
+
+export interface Data {
+  platformInfo: PlatformInfo;
+  userInfo: UserInfo;
+  metadata: DataMetadata;
+  segments: Segment[];
+  availableSegments: any[];
+  expiryDate: string;
+}
+
+export interface DataMetadata {
+  lastUpdated: LastUpdated;
+  isPC: boolean;
+  clubMiniName: null;
+  isPrivateCareerOverview: boolean;
+  isPrivateCareerStatistics: boolean;
+  isPrivateBattleHistory: boolean;
+  level: number;
+  gamemodes: Gamemode[];
+  currentSeason: number;
+  defaultSeason: number;
+  seasons: Season[];
+}
+
+export interface Gamemode {
+  id: string;
+  name: string;
+}
+
+export interface LastUpdated {
+  value: string;
+  displayValue: string;
+}
+
+export interface Season {
+  id: number;
+  name: string;
+  shortName: string;
+}
+
+export interface PlatformInfo {
+  platformSlug: string;
+  platformUserId: null;
+  platformUserHandle: string;
+  platformUserIdentifier: string;
+  avatarUrl: string;
+  additionalParameters: null;
+}
+
+export interface Segment {
+  type: Type;
+  attributes: Attributes;
+  metadata: SegmentMetadata;
+  expiryDate: string;
+  stats: Stats;
+}
+
+export interface Attributes {
+  season?: number;
+  mode?: Mode;
+  heroId?: number;
+  role?: Role;
+  roleId?: Role;
+}
+
+export enum Mode {
+  All = 'all'
+}
+
+export enum Role {
+  Duelist = 'duelist',
+  Strategist = 'strategist',
+  Vanguard = 'vanguard'
+}
+
+export interface SegmentMetadata {
+  name?: string;
+  imageUrl?: string;
+  roleName?: RoleName;
+  color?: string;
+}
+
+export enum RoleName {
+  Duelist = 'Duelist',
+  Strategist = 'Strategist',
+  Vanguard = 'Vanguard'
+}
+
+export interface Stats {
+  timePlayed?: Assists;
+  matchesPlayed?: Assists;
+  matchesWon?: Assists;
+  matchesWinPct?: Assists;
+  kills?: Assists;
+  deaths?: Assists;
+  assists?: Assists;
+  kdRatio?: Assists;
+  kdaRatio?: Assists;
+  totalHeroDamage?: Assists;
+  totalHeroDamagePerMinute?: Assists;
+  totalHeroHeal?: Assists;
+  totalHeroHealPerMinute?: Assists;
+  totalDamageTaken?: Assists;
+  totalDamageTakenPerMinute?: Assists;
+  lastKills?: Assists;
+  headKills?: Assists;
+  soloKills?: Assists;
+  maxSurvivalKills?: Assists;
+  maxContinueKills?: Assists;
+  continueKills3?: Assists;
+  continueKills4?: Assists;
+  continueKills5?: Assists;
+  continueKills6?: Assists;
+  mainAttacks?: Assists;
+  mainAttackHits?: Assists;
+  shieldHits?: Assists;
+  summonerHits?: Assists;
+  chaosHits?: Assists;
+  totalMvp?: Assists;
+  totalMvpPct?: Assists;
+  totalSvp?: Assists;
+  totalSvpPct?: Assists;
+  ranked?: Ranked;
+  peakRanked?: Ranked;
+  peakTiers?: PeakTiers;
+  lifetimePeakRanked?: LifetimePeakRanked;
+  timePlayedWon?: Assists;
+  survivalKills?: Assists;
+  continueKills?: Assists;
+  featureNormalData1?: Assists;
+  featureNormalData2?: Assists;
+  featureNormalData3?: Assists;
+  featureCriticalRate1CritHits?: Assists;
+  featureCriticalRate1Hits?: Assists;
+  featureCriticalRate2CritHits?: Assists;
+  featureCriticalRate2Hits?: Assists;
+  featureHitRate1UseCount?: Assists;
+  featureHitRate1RealHitHeroCount?: Assists;
+  featureHitRate1ChaosHits?: Assists;
+  featureHitRate1AllyHits?: Assists;
+  featureHitRate1HeroHits?: Assists;
+  featureHitRate1EnemyHits?: Assists;
+  featureHitRate1ShieldHits?: Assists;
+  featureHitRate1SummonerHits?: Assists;
+  featureHitRate2UseCount?: Assists;
+  featureHitRate2RealHitHeroCount?: Assists;
+  featureHitRate2ChaosHits?: Assists;
+  featureHitRate2AllyHits?: Assists;
+  featureHitRate2HeroHits?: Assists;
+  featureHitRate2EnemyHits?: Assists;
+  featureHitRate2ShieldHits?: Assists;
+  featureHitRate2SummonerHits?: Assists;
+  featureSpecialData1Total?: Assists;
+  featureSpecialData1Value?: Assists;
+}
+
+export interface Assists {
+  displayName: string;
+  displayCategory: DisplayCategory;
+  category: Category;
+  metadata: AssistsMetadata;
+  value: number | null;
+  displayValue: string | null;
+  displayType: AssistsDisplayType;
+  percentile?: number;
+}
+
+export enum Category {
+  Combat = 'combat',
+  Damage = 'damage',
+  Feature = 'feature',
+  Game = 'game',
+  Healing = 'healing'
+}
+
+export enum DisplayCategory {
+  Combat = 'Combat',
+  Damage = 'Damage',
+  Feature = 'Feature',
+  Game = 'Game',
+  Healing = 'Healing'
+}
+
+export enum AssistsDisplayType {
+  Number = 'Number',
+  NumberPercentage = 'NumberPercentage',
+  NumberPrecision1 = 'NumberPrecision1',
+  NumberPrecision2 = 'NumberPrecision2',
+  TimeSeconds = 'TimeSeconds'
+}
+
+export interface AssistsMetadata {}
+
+export interface LifetimePeakRanked {
+  displayName: DisplayName;
+  category?: string;
+  metadata: LifetimePeakRankedMetadata;
+  value: number;
+  displayValue: string | null;
+  displayType: LifetimePeakRankedDisplayType;
+}
+
+export enum DisplayName {
+  LifetimePeakRankScore = 'Lifetime Peak Rank Score',
+  PeakRating = 'Peak Rating'
+}
+
+export enum LifetimePeakRankedDisplayType {
+  Custom = 'Custom',
+  String = 'String'
+}
+
+export interface LifetimePeakRankedMetadata {
+  unit: Unit;
+  iconUrl: string;
+  tierName: string;
+  tierShortName: string;
+  color: string;
+  season: number;
+  seasonName: string;
+  seasonShortName: string;
+}
+
+export enum Unit {
+  Rs = 'RS'
+}
+
+export interface Ranked {
+  displayName: string;
+  category: string;
+  metadata: PeakRankedMetadata;
+  value: number;
+  displayValue: string;
+  displayType: LifetimePeakRankedDisplayType;
+}
+
+export interface PeakRankedMetadata {
+  unit: Unit;
+  iconUrl: string;
+  tierName: string;
+  tierShortName: string;
+  color: string;
+}
+
+export interface PeakTiers {
+  displayName: string;
+  metadata: AssistsMetadata;
+  value: LifetimePeakRanked[];
+  displayValue: null;
+  displayType: LifetimePeakRankedDisplayType;
+}
+
+export enum Type {
+  Hero = 'hero',
+  HeroRole = 'hero-role',
+  Overview = 'overview',
+  RankedPeaks = 'ranked-peaks'
+}
+
+export interface UserInfo {
+  userId: null;
+  isPremium: boolean;
+  isVerified: boolean;
+  isInfluencer: boolean;
+  isPartner: boolean;
+  countryCode: null;
+  customAvatarUrl: null;
+  customHeroUrl: null;
+  customAvatarFrame: null;
+  customAvatarFrameInfo: null;
+  premiumDuration: null;
+  socialAccounts: any[];
+  badges: null;
+  pageviews: number;
+  xpTier: null;
+  isSuspicious: null;
+}

--- a/src/lib/api/trackergg/dto/ProfileDTO.ts
+++ b/src/lib/api/trackergg/dto/ProfileDTO.ts
@@ -14,7 +14,7 @@ export interface Data {
 export interface DataMetadata {
   lastUpdated: LastUpdated;
   isPC: boolean;
-  clubMiniName: null;
+  clubMiniName: string | null;
   isPrivateCareerOverview: boolean;
   isPrivateCareerStatistics: boolean;
   isPrivateBattleHistory: boolean;

--- a/src/lib/api/trackergg/dto/ProfileDTO.ts
+++ b/src/lib/api/trackergg/dto/ProfileDTO.ts
@@ -14,7 +14,7 @@ export interface Data {
 export interface DataMetadata {
   lastUpdated: LastUpdated;
   isPC: boolean;
-  clubMiniName: null;
+  clubMiniName: string | null;
   isPrivateCareerOverview: boolean;
   isPrivateCareerStatistics: boolean;
   isPrivateBattleHistory: boolean;
@@ -192,7 +192,7 @@ export enum AssistsDisplayType {
   TimeSeconds = 'TimeSeconds'
 }
 
-export interface AssistsMetadata {}
+export interface AssistsMetadata { }
 
 export interface LifetimePeakRanked {
   displayName: DisplayName;

--- a/src/lib/api/trackergg/tracker-api.ts
+++ b/src/lib/api/trackergg/tracker-api.ts
@@ -6,15 +6,13 @@ import type { Profile } from './dto/ProfileDTO';
 
 import { AttackType, Role } from '../../../types/dtos/HeroesDTO';
 
-export type TrackerGameModes = 'competitive' | 'quick-match' | 'all'; // todo: ver si vale la pena agregar modos arcade y todo eso
-export const trackerModesMap: Record<
-  'ranked' | 'casual' | 'both',
-  TrackerGameModes
-> = {
+export type TrackerGameModes = 'competitive' | 'quick-match' | 'all';
+export const trackerModesMap = {
   ranked: 'competitive',
+  competitive: 'competitive',
   casual: 'quick-match',
   both: 'all'
-};
+} satisfies Partial<Record<string, TrackerGameModes>>;
 
 /**
  * Transforms Tracker.gg career API response data to PlayerDTO format.
@@ -36,37 +34,33 @@ export function transformCareerToPlayerDTO(
 
   const iconIdMatch = /\/(\d+)\.jpg/.exec(avatarUrl);
   const playerIconId = iconIdMatch
-? iconIdMatch[1]
-: '0';
+    ? iconIdMatch[1]
+    : '0';
 
   // Use career data for all stats and heroes (career endpoint has complete data)
   const overview = careerData.data.find((item) => item.type === 'overview');
   const heroSegments = careerData.data.filter((item) => item.type === 'hero');
 
-  if (!overview) {
-    throw new Error('Overview data not found in Career response');
-  }
-
   // Overall career stats
-  const stats = overview.stats;
-  const totalKills = Number(stats.kills?.value) || 0;
-  const totalDeaths = Number(stats.deaths?.value) || 0;
-  const totalAssists = Number(stats.assists?.value) || 0;
-  const totalWins = Number(stats.matchesWon?.value) || 0;
-  const totalMatches = Number(stats.matchesPlayed?.value) || 0;
-  const totalTimePlayedDispley = stats.timePlayed?.displayValue;
-  const totalTimePlayedValue = Number(stats.timePlayed?.value) || 0;
-  const totalMvp = Number(stats.totalMvp?.value) || 0;
-  const totalSvp = Number(stats.totalSvp?.value) || 0;
+  const stats = overview?.stats;
+  const totalKills = Number(stats?.kills?.value) || 0;
+  const totalDeaths = Number(stats?.deaths?.value) || 0;
+  const totalAssists = Number(stats?.assists?.value) || 0;
+  const totalWins = Number(stats?.matchesWon?.value) || 0;
+  const totalMatches = Number(stats?.matchesPlayed?.value) || 0;
+  const totalTimePlayedDispley = stats?.timePlayed?.displayValue;
+  const totalTimePlayedValue = Number(stats?.timePlayed?.value) || 0;
+  const totalMvp = Number(stats?.totalMvp?.value) || 0;
+  const totalSvp = Number(stats?.totalSvp?.value) || 0;
 
   // Rank information from career
-  const rankedStat = stats.ranked;
+  const rankedStat = stats?.ranked;
   const rankTier = rankedStat?.metadata.tierName || 'Unranked';
   const rankScore = Number(rankedStat?.value) || 0;
   const rankColor = rankedStat?.metadata.color ?? null;
   const rankIcon = rankedStat?.metadata.iconUrl ?? null;
 
-  const lifetimePeakStat = stats.lifetimePeakRanked;
+  const lifetimePeakStat = stats?.lifetimePeakRanked;
 
   // Map heroes from career data (uses CareerDTO Datum structure)
   const heroes: HeroesRanked[] = heroSegments.map((heroSegment) => transformHeroDataFromCareer(heroSegment));
@@ -101,8 +95,8 @@ export function transformCareerToPlayerDTO(
       info: {
         completed_achievements: '',
         login_os: metadata.isPC
-? 'pc'
-: 'console',
+          ? 'pc'
+          : 'console',
         rank_game_season: {
           1: {
             rank_game_id: 1,
@@ -110,8 +104,8 @@ export function transformCareerToPlayerDTO(
             rank_score: rankScore,
             max_level: lifetimePeakStat
               ? extractRankLevel(
-                  lifetimePeakStat.metadata?.tierName || rankTier
-                )
+                lifetimePeakStat.metadata.tierName || rankTier
+              )
               : extractRankLevel(rankTier),
             max_rank_score: Number(lifetimePeakStat?.value) || rankScore,
             update_time: new Date(metadata.lastUpdated.value).getTime(),
@@ -142,8 +136,8 @@ export function transformCareerToPlayerDTO(
         total_assists: Math.round(totalAssists),
         total_deaths: Math.round(totalDeaths),
         total_kills: Math.round(totalKills),
-        total_time_played: totalTimePlayedDispley, // nota: revisar "displayType" para saber q formato viene
-        total_time_played_raw: totalTimePlayedValue, //
+        total_time_played: totalTimePlayedDispley ?? undefined,
+        total_time_played_raw: totalTimePlayedValue,
         total_mvp: Math.round(totalMvp),
         total_svp: Math.round(totalSvp)
       }

--- a/src/lib/api/trackergg/tracker-api.ts
+++ b/src/lib/api/trackergg/tracker-api.ts
@@ -1,0 +1,270 @@
+import type { HeroesRanked, PlayerDTO } from '../../../types/dtos/PlayerDTO';
+import type { Welcome as TrackerHeroesMetadata } from './dto/HeroDTO';
+import type { HeroesDTO } from '../../../types/dtos/HeroesDTO';
+import type { CareerDTO, Datum } from './dto/CareerDTO';
+import type { Profile } from './dto/ProfileDTO';
+
+import { AttackType, Role } from '../../../types/dtos/HeroesDTO';
+
+export type TrackerGameModes = 'competitive' | 'quick-match' | 'all'; // todo: ver si vale la pena agregar modos arcade y todo eso
+export const trackerModesMap: Record<
+  'ranked' | 'casual' | 'both',
+  TrackerGameModes
+> = {
+  ranked: 'competitive',
+  casual: 'quick-match',
+  both: 'all'
+};
+
+/**
+ * Transforms Tracker.gg career API response data to PlayerDTO format.
+ * Uses Profile data to complete missing information like level, avatar, etc.
+ *
+ * Career URL: https://api.tracker.gg/api/v2/marvel-rivals/standard/profile/ign/{name}/segments/career?mode=all
+ * Profile URL: https://api.tracker.gg/api/v2/marvel-rivals/standard/profile/ign/{name}
+ */
+export function transformCareerToPlayerDTO(
+  careerData: CareerDTO,
+  profileData: Profile,
+  playerUid: number
+): PlayerDTO {
+  const { platformInfo, metadata } = profileData.data;
+
+  const playerName = platformInfo.platformUserHandle;
+  const playerLevel = metadata.level.toString();
+  const avatarUrl = platformInfo.avatarUrl;
+
+  const iconIdMatch = /\/(\d+)\.jpg/.exec(avatarUrl);
+  const playerIconId = iconIdMatch
+? iconIdMatch[1]
+: '0';
+
+  // Use career data for all stats and heroes (career endpoint has complete data)
+  const overview = careerData.data.find((item) => item.type === 'overview');
+  const heroSegments = careerData.data.filter((item) => item.type === 'hero');
+
+  if (!overview) {
+    throw new Error('Overview data not found in Career response');
+  }
+
+  // Overall career stats
+  const stats = overview.stats;
+  const totalKills = Number(stats.kills?.value) || 0;
+  const totalDeaths = Number(stats.deaths?.value) || 0;
+  const totalAssists = Number(stats.assists?.value) || 0;
+  const totalWins = Number(stats.matchesWon?.value) || 0;
+  const totalMatches = Number(stats.matchesPlayed?.value) || 0;
+  const totalTimePlayedDispley = stats.timePlayed?.displayValue;
+  const totalTimePlayedValue = Number(stats.timePlayed?.value) || 0;
+  const totalMvp = Number(stats.totalMvp?.value) || 0;
+  const totalSvp = Number(stats.totalSvp?.value) || 0;
+
+  // Rank information from career
+  const rankedStat = stats.ranked;
+  const rankTier = rankedStat?.metadata.tierName || 'Unranked';
+  const rankScore = Number(rankedStat?.value) || 0;
+  const rankColor = rankedStat?.metadata.color ?? null;
+  const rankIcon = rankedStat?.metadata.iconUrl ?? null;
+
+  const lifetimePeakStat = stats.lifetimePeakRanked;
+
+  // Map heroes from career data (uses CareerDTO Datum structure)
+  const heroes: HeroesRanked[] = heroSegments.map((heroSegment) => transformHeroDataFromCareer(heroSegment));
+
+  const heroesRanked = heroes.filter((h) => h.matches > 0);
+  const heroesUnranked: HeroesRanked[] = [];
+
+  const playerDTO: PlayerDTO = {
+    uid: playerUid,
+    name: playerName,
+    isPrivate:
+      metadata.isPrivateCareerOverview || metadata.isPrivateCareerStatistics,
+    player: {
+      uid: playerUid,
+      level: playerLevel,
+      name: playerName,
+      icon: {
+        player_icon_id: playerIconId,
+        player_icon: avatarUrl,
+        banner: undefined
+      },
+      rank: {
+        rank: rankTier,
+        image: rankIcon,
+        color: rankColor
+      },
+      team: {
+        club_team_id: '',
+        club_team_mini_name: metadata.clubMiniName || '',
+        club_team_type: ''
+      },
+      info: {
+        completed_achievements: '',
+        login_os: metadata.isPC
+? 'pc'
+: 'console',
+        rank_game_season: {
+          1: {
+            rank_game_id: 1,
+            level: extractRankLevel(rankTier),
+            rank_score: rankScore,
+            max_level: lifetimePeakStat
+              ? extractRankLevel(
+                  lifetimePeakStat.metadata?.tierName || rankTier
+                )
+              : extractRankLevel(rankTier),
+            max_rank_score: Number(lifetimePeakStat?.value) || rankScore,
+            update_time: new Date(metadata.lastUpdated.value).getTime(),
+            win_count: totalWins,
+            protect_score: 0,
+            diff_score: 0
+          }
+        }
+      }
+    },
+    overall_stats: {
+      total_matches: Math.round(totalMatches),
+      total_wins: Math.round(totalWins),
+      unranked: {
+        total_matches: 0,
+        total_wins: 0,
+        total_assists: 0,
+        total_deaths: 0,
+        total_kills: 0,
+        total_time_played: '0h 0m',
+        total_time_played_raw: 0,
+        total_mvp: 0,
+        total_svp: 0
+      },
+      ranked: {
+        total_matches: Math.round(totalMatches),
+        total_wins: Math.round(totalWins),
+        total_assists: Math.round(totalAssists),
+        total_deaths: Math.round(totalDeaths),
+        total_kills: Math.round(totalKills),
+        total_time_played: totalTimePlayedDispley, // nota: revisar "displayType" para saber q formato viene
+        total_time_played_raw: totalTimePlayedValue, //
+        total_mvp: Math.round(totalMvp),
+        total_svp: Math.round(totalSvp)
+      }
+    },
+    heroes_ranked: heroesRanked,
+    heroes_unranked: heroesUnranked,
+    updates: {
+      info_update_time: new Date(metadata.lastUpdated.value).toISOString(),
+      last_history_update: null,
+      last_inserted_match: null,
+      last_update_request: null
+    },
+    match_history: [],
+    rank_history: [],
+    hero_matchups: [],
+    team_mates: [],
+    maps: []
+  };
+
+  return playerDTO;
+}
+
+/**
+ * Transforms a single hero segment from tracker.gg into the HeroesRanked type
+ */
+function transformHeroDataFromCareer(hero: Datum): HeroesRanked {
+  const heroId = hero.attributes.heroId ?? 0;
+  const heroName = hero.metadata.name ?? 'Unknown';
+  const heroThumbnail = hero.metadata.imageUrl ?? '';
+
+  const stats = hero.stats;
+
+  return {
+    hero_id: heroId,
+    hero_name: heroName,
+    hero_thumbnail: heroThumbnail,
+    matches: Math.round(Number(stats.matchesPlayed?.value) || 0),
+    wins: Math.round(Number(stats.matchesWon?.value) || 0),
+    mvp: Math.round(Number(stats.totalMvp?.value) || 0),
+    svp: Math.round(Number(stats.totalSvp?.value) || 0),
+    kills: Math.round(Number(stats.kills?.value) || 0),
+    deaths: Math.round(Number(stats.deaths?.value) || 0),
+    assists: Math.round(Number(stats.assists?.value) || 0),
+    play_time: Math.round(Number(stats.timePlayed?.value) || 0),
+    damage: Math.round(Number(stats.totalHeroDamage?.value) || 0),
+    heal: Math.round(Number(stats.totalHeroHeal?.value) || 0),
+    damage_taken: Math.round(Number(stats.totalDamageTaken?.value) || 0),
+    main_attack: {
+      total: Math.round(Number(stats.mainAttacks?.value) || 0),
+      hits: Math.round(Number(stats.mainAttackHits?.value) || 0)
+    }
+  };
+}
+
+/**
+ * Extracts rank level from tier name
+ * Example: "Grandmaster III" -> 6
+ */
+function extractRankLevel(tierName: string): number {
+  const rankMap: Record<string, number> = {
+    bronze: 0,
+    silver: 1,
+    gold: 2,
+    platinum: 3,
+    diamond: 4,
+    grandmaster: 6,
+    eternity: 7,
+    celestial: 8,
+    'one above all': 9
+  };
+
+  const tierLower = tierName.toLowerCase();
+  for (const [rank, level] of Object.entries(rankMap)) {
+    if (tierLower.includes(rank)) {
+      return level;
+    }
+  }
+
+  return 0;
+}
+
+/**
+ * Transforms Tracker.gg heroes metadata to HeroesDTO format.
+ * API URL: https://api.tracker.gg/api/v1/marvel-rivals/metadata/type/hero
+ */
+export function transformTrackerHeroesToHeroesDTO(
+  trackerData: TrackerHeroesMetadata
+): HeroesDTO[] {
+  return trackerData.data.items.map((hero) => {
+    const role = mapRoleToHeroesDTO(hero.roleName);
+
+    return {
+      id: hero.key,
+      name: hero.name,
+      real_name: '',
+      imageUrl: hero.imageUrl,
+      role,
+      attack_type: AttackType.Projectile, // no viene en el tracker salu2
+      team: [],
+      difficulty: '',
+      bio: hero.description,
+      lore: '',
+      transformations: [],
+      costumes: [],
+      abilities: []
+    };
+  });
+}
+
+/**
+ * Maps Tracker.gg role name to HeroesDTO Role enum
+ */
+function mapRoleToHeroesDTO(roleName: string): Role {
+  switch (roleName) {
+    case 'Duelist':
+      return Role.Duelist;
+    case 'Strategist':
+      return Role.Strategist;
+    case 'Vanguard':
+      return Role.Vanguard;
+    default:
+      return Role.Duelist; // Default fallback
+  }
+}

--- a/src/lib/managers/api.ts
+++ b/src/lib/managers/api.ts
@@ -1,37 +1,37 @@
-import { MergeOptions, LogLevels, Logger } from "seyfert/lib/common";
-import { type IValidation, createValidate } from "typia";
-import { Bucket } from "seyfert/lib/api/bucket";
+import { MergeOptions, LogLevels, Logger } from 'seyfert/lib/common';
+import { type IValidation, createValidate } from 'typia';
+import { Bucket } from 'seyfert/lib/api/bucket';
 
 import type {
   MatchHistoryDTO,
-  MatchHistory,
-} from "../../types/dtos/MatchHistoryDTO";
-import type { LeaderboardPlayerHeroDTO } from "../../types/dtos/LeaderboardPlayerHeroDTO";
+  MatchHistory
+} from '../../types/dtos/MatchHistoryDTO';
 import type {
   FormattedPatch,
-  PatchNotesDTO,
-} from "../../types/dtos/PatchNotesDTO";
-import type { Welcome as TrackerHeroesMetadata } from "../api/trackergg/dto/HeroDTO";
-import type { AutocompleteDTO } from "../../types/dtos/AutocompleteDTO";
-import type { FoundPlayerDTO } from "../../types/dtos/FoundPlayerDTO";
-import type { GameModes } from "../../utils/images/match-history";
-import type { CareerDTO } from "../api/trackergg/dto/CareerDTO";
-import type { Profile } from "../api/trackergg/dto/ProfileDTO";
-import type { HeroesDTO } from "../../types/dtos/HeroesDTO";
-import type { PlayerDTO } from "../../types/dtos/PlayerDTO";
-import type { UpdateDTO } from "../../types/dtos/UpdateDTO";
-import type { HeroDTO } from "../../types/dtos/HeroDTO";
-import type { MapsDTO } from "../../types/dtos/MapsDTO";
-import type { MapDTO } from "../../types/dtos/MapsDTO";
+  PatchNotesDTO
+} from '../../types/dtos/PatchNotesDTO';
+import type { LeaderboardPlayerHeroDTO } from '../../types/dtos/LeaderboardPlayerHeroDTO';
+import type { Welcome as TrackerHeroesMetadata } from '../api/trackergg/dto/HeroDTO';
+import type { AutocompleteDTO } from '../../types/dtos/AutocompleteDTO';
+import type { FoundPlayerDTO } from '../../types/dtos/FoundPlayerDTO';
+import type { GameModes } from '../../utils/images/match-history';
+import type { CareerDTO } from '../api/trackergg/dto/CareerDTO';
+import type { Profile } from '../api/trackergg/dto/ProfileDTO';
+import type { HeroesDTO } from '../../types/dtos/HeroesDTO';
+import type { PlayerDTO } from '../../types/dtos/PlayerDTO';
+import type { UpdateDTO } from '../../types/dtos/UpdateDTO';
+import type { HeroDTO } from '../../types/dtos/HeroDTO';
+import type { MapsDTO } from '../../types/dtos/MapsDTO';
+import type { MapDTO } from '../../types/dtos/MapsDTO';
 
 import {
   transformTrackerHeroesToHeroesDTO,
   transformCareerToPlayerDTO,
-  type TrackerGameModes,
-} from "../api/trackergg/tracker-api";
-import { MARVELRIVALS_DOMAIN, TRACKER_DOMAIN } from "../../utils/env";
-import { Seasons } from "../../utils/constants";
-import { isProduction } from "../constants";
+  type TrackerGameModes
+} from '../api/trackergg/tracker-api';
+import { MARVELRIVALS_DOMAIN, TRACKER_DOMAIN } from '../../utils/env';
+import { Seasons } from '../../utils/constants';
+import { isProduction } from '../constants';
 
 const validateHeroes = createValidate<HeroesDTO[]>();
 const validateHero = createValidate<HeroDTO>();
@@ -53,8 +53,10 @@ export class Api {
   ratelimits = new Map<string, Bucket>();
 
   logger = new Logger({
-    name: "[Rivals API]",
-    logLevel: isProduction ? LogLevels.Info : LogLevels.Debug,
+    name: '[Rivals API]',
+    logLevel: isProduction
+      ? LogLevels.Info
+      : LogLevels.Debug
   });
 
   private readonly baseTrackerApiUrl: string = TRACKER_DOMAIN;
@@ -74,9 +76,9 @@ export class Api {
   constructor(
     private readonly apiKeys: string[],
     private readonly redisClient: ReturnType<
-      (typeof import("@redis/client"))["createClient"]
-    >,
-  ) {}
+      (typeof import('@redis/client'))['createClient']
+    >
+  ) { }
 
   public buildImage(path: string) {
     return `${this.cdnUrl}${path}`;
@@ -93,9 +95,9 @@ export class Api {
   // Utils
   async getRankHistory(
     userId: string,
-    season: (typeof Seasons)[number]["value"] = Seasons[Seasons.length - 1]
+    season: (typeof Seasons)[number]['value'] = Seasons[Seasons.length - 1]
       .value,
-    limit = Infinity,
+    limit = Infinity
   ) {
     const history: MatchHistory[] = [];
     let data: MatchHistoryDTO | null;
@@ -104,7 +106,7 @@ export class Api {
       data = await this.getMatchHistory(userId, {
         page,
         season,
-        game_mode: 2, // ranked
+        game_mode: 2 // ranked
       });
       if (data?.match_history.length) {
         history.push(...data.match_history);
@@ -114,23 +116,27 @@ export class Api {
       }
     } while (data?.pagination.has_more && history.length < limit);
 
-    return limit === Infinity ? history : history.slice(0, limit);
+    return limit === Infinity
+      ? history
+      : history.slice(0, limit);
   }
 
   async getAllHistory(
     userId: string,
     options?: Omit<
-      NonNullable<Parameters<(typeof this)["getMatchHistory"]>[1]>,
-      "limit"
-    >,
+      NonNullable<Parameters<(typeof this)['getMatchHistory']>[1]>,
+      'limit'
+    >
   ) {
     const history: MatchHistory[] = [];
     let data: MatchHistoryDTO | null;
-    let page = options?.page ? options.page - 1 : 0;
+    let page = options?.page
+      ? options.page - 1
+      : 0;
     do {
       data = await this.getMatchHistory(userId, {
         ...options,
-        page,
+        page
       });
       if (data?.match_history.length) {
         history.push(...data.match_history);
@@ -147,14 +153,14 @@ export class Api {
   public getMaps(page: number) {
     return this.fetchWithRetry({
       domain: this.marvelRivalsApiUrlV1,
-      endpoint: "maps",
+      endpoint: 'maps',
       validator: validateMaps,
-      cacheKey: "maps",
+      cacheKey: 'maps',
       expireTime: 24 * 60 * 60,
-      route: "maps",
+      route: 'maps',
       query: {
-        page,
-      },
+        page
+      }
     });
   }
 
@@ -179,21 +185,21 @@ export class Api {
       validator: validateFormattedPatch,
       cacheKey: `patch-note/${id}`,
       expireTime: 24 * 60 * 60,
-      route: "patch-note/:id",
+      route: 'patch-note/:id'
     });
   }
 
   public getPatchNotes(page = 1) {
     return this.fetchWithRetry({
       domain: this.marvelRivalsApiUrlV1,
-      endpoint: "patch-notes",
+      endpoint: 'patch-notes',
       validator: validatePatchNotes,
-      cacheKey: "patch-notes",
+      cacheKey: 'patch-notes',
       expireTime: 24 * 60 * 60,
       query: {
-        page,
+        page
       },
-      route: "patch-notes",
+      route: 'patch-notes'
     });
   }
 
@@ -214,13 +220,13 @@ export class Api {
   public getMatchHistory(
     userNameOrId: string,
     options: {
-      season?: (typeof Seasons)[number]["value"];
+      season?: (typeof Seasons)[number]['value'];
       page?: number;
       limit?: number;
       skip?: number;
-      game_mode?: (typeof GameModes)[number]["value"];
+      game_mode?: (typeof GameModes)[number]['value'];
       timestamp?: number;
-    } = {},
+    } = {}
   ) {
     options = MergeOptions(
       {
@@ -229,9 +235,9 @@ export class Api {
         limit: 40,
         skip: 0,
         game_mode: 0,
-        timestamp: undefined,
+        timestamp: undefined
       },
-      options,
+      options
     );
 
     return this.fetchWithRetry({
@@ -240,8 +246,8 @@ export class Api {
       validator: validateMatchHistory,
       cacheKey: `match-history/${userNameOrId}`,
       expireTime: 5 * 60,
-      route: "match-history/:id",
-      query: options,
+      route: 'match-history/:id',
+      query: options
     });
   }
 
@@ -251,7 +257,7 @@ export class Api {
       domain: this.marvelRivalsApiUrlV1,
       endpoint: `player/${id}/update`,
       validator: validateUpdatedPlayer,
-      route: "player/:id/update",
+      route: 'player/:id/update'
     });
   }
 
@@ -262,13 +268,13 @@ export class Api {
       validator: validateFoundPlayer,
       cacheKey: `find-player/${username}`,
       expireTime: 30 * 60,
-      route: "find-player/:id",
+      route: 'find-player/:id'
     });
   }
 
   public async getPlayer(
     nameOrId: string,
-    options?: Parameters<typeof this.fetchPlayer>[1],
+    options?: Parameters<typeof this.fetchPlayer>[1]
   ) {
     if (/^\d+$/.exec(nameOrId)) {
       return this.fetchPlayer(nameOrId, options);
@@ -284,14 +290,14 @@ export class Api {
   fetchPlayer(
     id: string,
     options: {
-      season?: (typeof Seasons)[number]["value"];
-    } = {},
+      season?: (typeof Seasons)[number]['value'];
+    } = {}
   ) {
     options = MergeOptions(
       {
-        season: Seasons[Seasons.length - 1].value,
+        season: Seasons[Seasons.length - 1].value
       },
-      options,
+      options
     );
     return this.fetchWithRetry({
       domain: this.marvelRivalsApiUrlV1,
@@ -299,15 +305,15 @@ export class Api {
       validator: validatePlayer,
       cacheKey: `player/${id}`,
       expireTime: 5 * 60,
-      route: "player/:id",
-      query: options,
+      route: 'player/:id',
+      query: options
     });
   }
 
   // Heroes
   public getLeaderboardHero(
     nameOrId: string,
-    platform: "xbox" | "pc" | "ps" = "pc",
+    platform: 'xbox' | 'pc' | 'ps' = 'pc'
   ) {
     return this.fetchWithRetry({
       domain: this.marvelRivalsApiUrlV1,
@@ -315,21 +321,21 @@ export class Api {
       validator: validateLeaderboardPlayerHero,
       cacheKey: `leaderboard-hero/${nameOrId}/${platform}`,
       query: {
-        platform,
+        platform
       },
       expireTime: 15 * 60,
-      route: "heroes/leaderboard/:id",
+      route: 'heroes/leaderboard/:id'
     });
   }
 
   public async getHeroes() {
     const heroes = await this.fetchWithRetry({
       domain: this.marvelRivalsApiUrlV1,
-      endpoint: "heroes",
+      endpoint: 'heroes',
       validator: validateHeroes,
-      cacheKey: "heroes",
+      cacheKey: 'heroes',
       expireTime: 24 * 60 * 60,
-      route: "heroes",
+      route: 'heroes'
     });
     return heroes ?? [];
   }
@@ -341,7 +347,7 @@ export class Api {
       validator: validateHero,
       cacheKey: `hero/${nameOrId}`,
       expireTime: 24 * 60 * 60,
-      route: "heroes/hero/:id",
+      route: 'heroes/hero/:id'
     });
   }
 
@@ -355,13 +361,13 @@ export class Api {
     expireTime,
     route,
     retries = 3,
-    tries = 0,
+    tries = 0
   }: {
     endpoint: string;
     domain: Api[
-      | "marvelRivalsApiUrlV1"
-      | "marvelRivalsApiUrlV2"
-      | "trackerApiUrlV2"];
+    | 'marvelRivalsApiUrlV1'
+    | 'marvelRivalsApiUrlV2'
+    | 'trackerApiUrlV2'];
     route: string;
     validator: (data: unknown) => IValidation<T>;
     cacheKey?: string;
@@ -371,19 +377,18 @@ export class Api {
     expireTime?: number;
   }): Promise<null | T> {
     if (cacheKey) {
-      cacheKey = `${cacheKey}${
-        query
-          ? Object.entries(query)
-              .filter(
-                (kv): kv is [string, string | number] => kv.at(1) !== undefined,
-              )
-              .map((kv) => `${kv[0]}${kv[1]}`)
-              .join("_")
-          : ""
-      }`;
+      cacheKey = `${cacheKey}${query
+        ? Object.entries(query)
+          .filter(
+            (kv): kv is [string, string | number] => kv.at(1) !== undefined
+          )
+          .map((kv) => `${kv[0]}${kv[1]}`)
+          .join('_')
+        : ''
+        }`;
       const cachedData = await this.redisClient.GET(cacheKey);
       if (cachedData) {
-        if (cachedData === "null") {
+        if (cachedData === 'null') {
           return null;
         }
         return JSON.parse(cachedData) as T;
@@ -397,24 +402,23 @@ export class Api {
       endpoint,
       query: query
         ? new URLSearchParams(
-            Object.fromEntries(
-              Object.entries(query)
-                .filter(
-                  (kv): kv is [string, string | number] =>
-                    kv.at(1) !== undefined,
-                )
-                .map(([key, value]) => [key, value.toString()] as const),
-            ),
+          Object.fromEntries(
+            Object.entries(query)
+              .filter(
+                (kv): kv is [string, string | number] => kv.at(1) !== undefined
+              )
+              .map(([key, value]) => [key, value.toString()] as const)
           )
+        )
         : undefined,
-      route,
+      route
     });
 
     // Si la respuesta es 404 (Not Found), retorna null
     if (response.status === 404) {
       if (cacheKey) {
-        await this.redisClient.SET(cacheKey, "null", {
-          EX: expireTime,
+        await this.redisClient.SET(cacheKey, 'null', {
+          EX: expireTime
         });
       }
       return null;
@@ -432,7 +436,7 @@ export class Api {
           expireTime,
           route,
           retries,
-          tries: tries + 1,
+          tries: tries + 1
         });
       }
       const text = await response.text();
@@ -441,7 +445,7 @@ export class Api {
       try {
         err = (JSON.parse(text) as { message?: string }).message;
         if (!err) {
-          throw new Error("unknown error");
+          throw new Error('unknown error');
         }
       } catch {
         err = text;
@@ -458,12 +462,12 @@ export class Api {
       throw new Error(
         check.errors
           .map((err) => `Expected: ${err.expected} on ${err.path}`)
-          .join("\n"),
+          .join('\n')
       );
     }
     if (cacheKey) {
       await this.redisClient.SET(cacheKey, JSON.stringify(check.data), {
-        EX: expireTime,
+        EX: expireTime
       });
     }
     return check.data;
@@ -473,9 +477,9 @@ export class Api {
     domain,
     endpoint,
     query,
-    route,
+    route
   }: {
-    domain: Api["marvelRivalsApiUrlV1" | "marvelRivalsApiUrlV2"];
+    domain: Api['marvelRivalsApiUrlV1' | 'marvelRivalsApiUrlV2'];
     endpoint: string;
     query?: URLSearchParams;
     route: string;
@@ -483,34 +487,34 @@ export class Api {
     const callback = async (
       next: () => void,
       resolve: (data: Response) => void,
-      reject: (err: unknown) => void,
+      reject: (err: unknown) => void
     ) => {
-      const url = `${domain}/${endpoint}?${query ?? ""}`;
+      const url = `${domain}/${endpoint}?${query ?? ''}`;
       const bucket = this.ratelimits.get(route)!;
       const headers = {
-        "x-api-key": this.rotateApiKey(),
-        "Content-Type": "application/json",
-        "User-Agent": "Chrome/121",
-        Accept: "application/json",
-        "Accept-Language": "es-AR,en;q=0.9",
-        "Accept-Encoding": "gzip, deflate, br",
-        Connection: "keep-alive",
-        "Cache-Control": "no-cache",
-        Pragma: "no-cache",
-        DNT: "1",
-        "Upgrade-Insecure-Requests": "1",
+        'x-api-key': this.rotateApiKey(),
+        'Content-Type': 'application/json',
+        'User-Agent': 'Chrome/121',
+        Accept: 'application/json',
+        'Accept-Language': 'es-AR,en;q=0.9',
+        'Accept-Encoding': 'gzip, deflate, br',
+        Connection: 'keep-alive',
+        'Cache-Control': 'no-cache',
+        Pragma: 'no-cache',
+        DNT: '1',
+        'Upgrade-Insecure-Requests': '1'
       };
 
       const response = await fetch(url, {
         headers,
-        credentials: "omit",
-        referrerPolicy: "strict-origin-when-cross-origin",
-        mode: "cors",
+        credentials: 'omit',
+        referrerPolicy: 'strict-origin-when-cross-origin',
+        mode: 'cors'
       });
 
-      const xRatelimitLimit = response.headers.get("x-ratelimit-limit");
-      const xRatelimitRemaining = response.headers.get("x-ratelimit-remaining");
-      const xRatelimitReset = response.headers.get("x-ratelimit-reset");
+      const xRatelimitLimit = response.headers.get('x-ratelimit-limit');
+      const xRatelimitRemaining = response.headers.get('x-ratelimit-remaining');
+      const xRatelimitReset = response.headers.get('x-ratelimit-reset');
 
       if (
         xRatelimitLimit !== null &&
@@ -518,9 +522,9 @@ export class Api {
         xRatelimitReset !== null
       ) {
         if (
-          xRatelimitLimit === "cache" ||
-          xRatelimitRemaining === "cache" ||
-          xRatelimitReset === "cache"
+          xRatelimitLimit === 'cache' ||
+          xRatelimitRemaining === 'cache' ||
+          xRatelimitReset === 'cache'
         ) {
           //
         } else {
@@ -551,7 +555,7 @@ export class Api {
                 }[];
               }
             ).errors?.[0].message ??
-            "Unknown error";
+            'Unknown error';
         } catch {
           errorMessage = `API request failed with status ${response.status}: ${response.statusText}`;
         }
@@ -572,7 +576,7 @@ export class Api {
     this.ratelimits.get(route)!.push({
       next: callback,
       resolve,
-      reject,
+      reject
     });
 
     return promise;
@@ -582,16 +586,16 @@ export class Api {
   autocompletePlayerNames(query: string) {
     return this.fetchWithRetry({
       domain: this.trackerApiUrlV2,
-      endpoint: "marvel-rivals/standard/search",
+      endpoint: 'marvel-rivals/standard/search',
       validator: validateAutocompletePlayerNames,
-      route: "marvel-rivals/standard/search",
+      route: 'marvel-rivals/standard/search',
       query: {
-        platform: "ign",
+        platform: 'ign',
         query,
-        autocomplete: "true",
+        autocomplete: 'true'
       },
       cacheKey: `autocomplete/${query}`,
-      expireTime: 12 * 60 * 60,
+      expireTime: 12 * 60 * 60
     });
   }
 
@@ -601,9 +605,9 @@ export class Api {
       domain: this.trackerApiUrlV2,
       endpoint: `marvel-rivals/standard/profile/ign/${encodeURIComponent(nameOrId)}`,
       validator: validateProfile,
-      route: "marvel-rivals/standard/profile/ign/:id",
+      route: 'marvel-rivals/standard/profile/ign/:id',
       cacheKey: `trackergg/profile/ign/${nameOrId}`,
-      expireTime: 5 * 60,
+      expireTime: 5 * 60
     });
 
     if (!data) {
@@ -616,11 +620,11 @@ export class Api {
   async getTrackerHeroesMetadata() {
     const data = await this.fetchWithRetry({
       domain: `${this.baseTrackerApiUrl}/api/v1`,
-      endpoint: "marvel-rivals/metadata/type/hero",
+      endpoint: 'marvel-rivals/metadata/type/hero',
       validator: validateTrackerHeroesMetadata,
-      route: "marvel-rivals/metadata/type/hero",
-      cacheKey: "trackergg/heroes",
-      expireTime: 24 * 60 * 60,
+      route: 'marvel-rivals/metadata/type/hero',
+      cacheKey: 'trackergg/heroes',
+      expireTime: 24 * 60 * 60
     });
 
     if (!data) {
@@ -632,27 +636,28 @@ export class Api {
 
   async getPlayerCareerData(
     nameOrId: string,
-    mode: TrackerGameModes = "all",
-    season: number | "all" = 13,
+    mode: TrackerGameModes = 'all',
+    season: number | 'all' = 13
   ) {
     const [data, profile] = await Promise.all([
       this.fetchWithRetry({
         domain: this.trackerApiUrlV2,
         endpoint: `marvel-rivals/standard/profile/ign/${encodeURIComponent(
-          nameOrId,
+          nameOrId
         )}/segments/career`,
         validator: validatePlayerCareerData,
-        route: "marvel-rivals/standard/profile/:id/segments/career",
-        cacheKey: `trackergg/player/career/ign/${nameOrId}/${mode}${
-          season ? `/${season}` : ""
-        }`,
+        route: 'marvel-rivals/standard/profile/:id/segments/career',
+        cacheKey: `trackergg/player/career/ign/${nameOrId}/${mode}${season
+          ? `/${season}`
+          : ''
+          }`,
         expireTime: 5 * 60,
         query: {
           mode,
-          ...(season && { season }),
-        },
+          ...season && { season }
+        }
       }),
-      this.getTrackerProfile(nameOrId),
+      this.getTrackerProfile(nameOrId)
     ]);
 
     if (!data || !profile) {
@@ -662,7 +667,9 @@ export class Api {
     return transformCareerToPlayerDTO(
       data,
       profile,
-      typeof nameOrId === "number" ? nameOrId : 67,
+      typeof nameOrId === 'number'
+        ? nameOrId
+        : 67
     );
   }
 }

--- a/src/locales/en-US/commands.ts
+++ b/src/locales/en-US/commands.ts
@@ -7,7 +7,8 @@ export const commands = {
         noNameOrId: ':warning: No player name or ID provided. This is required to proceed.',
         noName: ':warning: No player name provided. This is required to proceed.',
         underDevelopment: ':warning: This command is under development. It will be available soon. Sorry for the inconvenience.',
-        privateProfile: ':warning: This profile is set to private in game. To change this, follow the directions shown and try again.'
+        privateProfile: ':warning: This profile is set to private in game. To change this, follow the directions shown and try again.',
+        invalidSeason: ':warning: Invalid season. Please provide a valid season number or "all".'
     },
     commonOptions: {
         nameOrId: {

--- a/src/locales/es-419/commands.ts
+++ b/src/locales/es-419/commands.ts
@@ -9,7 +9,8 @@ const commands = {
         noNameOrId: ':warning: No se proporcionó nombre o ID. Este dato es necesario para continuar.',
         noName: ':warning: No se proporcionó nombre del jugador. Este dato es necesario para continuar.',
         underDevelopment: ':warning: Este comando está en desarrollo. Pronto estará disponible. Disculpa las molestias.',
-        privateProfile: ':warning: Este perfil está configurado como privado en el juego. Para cambiarlo, sigue las instrucciones que se muestran e intenta de nuevo.'
+        privateProfile: ':warning: Este perfil está configurado como privado en el juego. Para cambiarlo, sigue las instrucciones que se muestran e intenta de nuevo.',
+        invalidSeason: ':warning: Temporada inválida. Por favor proporciona un número de temporada válido o "all".'
     },
     commonOptions: {
         nameOrId: {

--- a/src/types/dtos/PlayerDTO.ts
+++ b/src/types/dtos/PlayerDTO.ts
@@ -116,7 +116,7 @@ export interface Ranked {
   readonly total_assists: number;
   readonly total_deaths: number;
   readonly total_kills: number;
-  readonly total_time_played: string;
+  readonly total_time_played?: string;
   readonly total_time_played_raw: number;
   readonly total_mvp: number;
   readonly total_svp: number;

--- a/src/utils/images/profile.ts
+++ b/src/utils/images/profile.ts
@@ -197,31 +197,33 @@ export async function generateProfileV2(data: PlayerDTO, allHeroes: HeroesDTO[],
 
     ctx.font = '900 23px RefrigeratorDeluxeBold';
     {
-        ctx.fillStyle = '#cd773c';
-        const damageNumberText = (damage / play_time * 60 || 0).toFixed(0);
-        const damageNumberMetrics = ctx.measureText(damageNumberText);
-        ctx.fillText(damageNumberText, 130 - damageNumberMetrics.width / 2, 647);
+      ctx.fillStyle = '#cd773c';
+      const damageNumberText = (damage / play_time * 60 || 0).toFixed(0);
+      const damageNumberMetrics = ctx.measureText(damageNumberText);
+      ctx.fillText(damageNumberText, 110, 647);
 
-        ctx.fillStyle = 'white';
-        ctx.fillText('damage dealt', damageNumberMetrics.width + 120, 647);
+      ctx.fillStyle = 'white';
+      ctx.fillText('damage dealt', damageNumberMetrics.width + 120, 647);
     }
     {
-        ctx.fillStyle = '#80b1b4';
-        const damageTakenNumberText = (damage_taken / play_time * 60 || 0).toFixed(0);
-        const damageTakenNumberMetrics = ctx.measureText(damageTakenNumberText);
-        ctx.fillText(damageTakenNumberText, 130 - damageTakenNumberMetrics.width / 2, 683);
+      ctx.fillStyle = '#80b1b4';
+      const damageTakenNumberText = (
+        damage_taken / play_time * 60 || 0
+      ).toFixed(0);
+      const damageTakenNumberMetrics = ctx.measureText(damageTakenNumberText);
+      ctx.fillText(damageTakenNumberText, 110, 683);
 
-        ctx.fillStyle = 'white';
-        ctx.fillText('damage taken', damageTakenNumberMetrics.width + 120, 683);
+      ctx.fillStyle = 'white';
+      ctx.fillText('damage taken', damageTakenNumberMetrics.width + 120, 683);
     }
     {
-        ctx.fillStyle = '#a4ba7a';
-        const healNumberText = (heal / play_time * 60 || 0).toFixed(0);
-        const healNumberMetrics = ctx.measureText(healNumberText);
-        ctx.fillText(healNumberText, 130 - healNumberMetrics.width / 2, 719);
+      ctx.fillStyle = '#a4ba7a';
+      const healNumberText = (heal / play_time * 60 || 0).toFixed(0);
+      const healNumberMetrics = ctx.measureText(healNumberText);
+      ctx.fillText(healNumberText, 110, 719);
 
-        ctx.fillStyle = 'white';
-        ctx.fillText('healing done', healNumberMetrics.width + 120, 719);
+      ctx.fillStyle = 'white';
+      ctx.fillText('healing done', healNumberMetrics.width + 120, 719);
     }
 
     ctx.font = '900 30px RefrigeratorDeluxeBold';

--- a/src/utils/images/profile.ts
+++ b/src/utils/images/profile.ts
@@ -197,33 +197,33 @@ export async function generateProfileV2(data: PlayerDTO, allHeroes: HeroesDTO[],
 
     ctx.font = '900 23px RefrigeratorDeluxeBold';
     {
-      ctx.fillStyle = '#cd773c';
-      const damageNumberText = (damage / play_time * 60 || 0).toFixed(0);
-      const damageNumberMetrics = ctx.measureText(damageNumberText);
-      ctx.fillText(damageNumberText, 110, 647);
+        ctx.fillStyle = '#cd773c';
+        const damageNumberText = (damage / play_time * 60 || 0).toFixed(0);
+        const damageNumberMetrics = ctx.measureText(damageNumberText);
+        ctx.fillText(damageNumberText, 110, 647);
 
-      ctx.fillStyle = 'white';
-      ctx.fillText('damage dealt', damageNumberMetrics.width + 120, 647);
+        ctx.fillStyle = 'white';
+        ctx.fillText('damage dealt', damageNumberMetrics.width + 120, 647);
     }
     {
-      ctx.fillStyle = '#80b1b4';
-      const damageTakenNumberText = (
-        damage_taken / play_time * 60 || 0
-      ).toFixed(0);
-      const damageTakenNumberMetrics = ctx.measureText(damageTakenNumberText);
-      ctx.fillText(damageTakenNumberText, 110, 683);
+        ctx.fillStyle = '#80b1b4';
+        const damageTakenNumberText = (
+            damage_taken / play_time * 60 || 0
+        ).toFixed(0);
+        const damageTakenNumberMetrics = ctx.measureText(damageTakenNumberText);
+        ctx.fillText(damageTakenNumberText, 110, 683);
 
-      ctx.fillStyle = 'white';
-      ctx.fillText('damage taken', damageTakenNumberMetrics.width + 120, 683);
+        ctx.fillStyle = 'white';
+        ctx.fillText('damage taken', damageTakenNumberMetrics.width + 120, 683);
     }
     {
-      ctx.fillStyle = '#a4ba7a';
-      const healNumberText = (heal / play_time * 60 || 0).toFixed(0);
-      const healNumberMetrics = ctx.measureText(healNumberText);
-      ctx.fillText(healNumberText, 110, 719);
+        ctx.fillStyle = '#a4ba7a';
+        const healNumberText = (heal / play_time * 60 || 0).toFixed(0);
+        const healNumberMetrics = ctx.measureText(healNumberText);
+        ctx.fillText(healNumberText, 110, 719);
 
-      ctx.fillStyle = 'white';
-      ctx.fillText('healing done', healNumberMetrics.width + 120, 719);
+        ctx.fillStyle = 'white';
+        ctx.fillText('healing done', healNumberMetrics.width + 120, 719);
     }
 
     ctx.font = '900 30px RefrigeratorDeluxeBold';


### PR DESCRIPTION
## Cambios Principales
- El comando `player profile` ahora usa la api de Tracker.gg (/metadata/type/hero, /standard/profile/ign/:id y /standard/profile/:id/segments/career)
- Se agrego un nuevo filtro para mostrar una season en especifico o todas

## Notas:
- eslint no esta formateando bien al parecer
- La api no parece devolver ningún uid por ningún lado, entonces convendría evaluar si mantenerlo en la imagen final o ver de donde se saca
- Las seasons estan [hardcodeadas](https://github.com/Datzu712/Spider-Byte/blob/7ba9c21b999d492137612de3f6ac81d071d32807/src/commands/player/profile.ts#L115C1-L115C47)